### PR TITLE
Include support for to graft in additional packages to processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Options:
                                                              |SearchParameter|ConceptMap|StructureMap|Library]
   -sf, --selectFiles <selectFiles>                           Only process these selected files
                                                              (e.g. package/SearchParameter-valueset-extensions-ValueSet-end.json)
+  -ap, --AdditionalPackages <packageId|ver>                  Set of additional packages to include in the processing
+                                                             These will be processes as though they are dependencies of the root package
   -if, --ignoreFiles <ignoreFiles>                           Any specific files that should be ignored/skipped when processing the
                                                              package
   -ic, --ignoreCanonicals <ignoreCanonicals>                 Any specific Canonical URls that should be ignored/skipped when
@@ -464,7 +466,13 @@ using the `-pcv` Patch Canonical Versions flag
 
 ## Change history
 
-### 5 February 2025
+### 6 March 2025
+* Add the `-ap` or `--AdditionalPackages` flag to include additional packages in the processing<br/>
+  *These will be processed as though they are dependencies of the root package.*
+  *This is useful if you want to include additional packages that are not dependencies of the root package*
+  *Particularly to resolve resources from a newer terminology.hl7.org or hl7.fhir.uv.extensions package version*
+
+### 5 March 2025
 This has been a big release with lots of changes, mostly around processing dependencies
 
 * References both fhir package registries to resolve dependencies (https://packages.simplifier.net and https://packages2.fhir.org/packages)

--- a/UploadFIG.Test/PrepareDependantPackage.cs
+++ b/UploadFIG.Test/PrepareDependantPackage.cs
@@ -214,13 +214,13 @@ namespace UploadFIG.Test
 			}
 
 			// Also scan the resources required by these dependencies
-			var packageContents = output.containedCanonicals.Select(ec => new CanonicalDetails() { resourceType = ec.resourceType, canonical = ec.canonical, version = ec.version }).ToList();
+			var packageContents = output.containedCanonicals.Select(ec => new CanonicalDetails() { ResourceType = ec.ResourceType, Canonical = ec.Canonical, Version = ec.Version }).ToList();
 			var downloadedResources = bun.Entry.Select(e => e.Resource).ToList();
 			var downloadedContents = downloadedResources.Select(ec => new CanonicalDetails() 
 			{ 
-				resourceType = ec.TypeName, 
-				canonical = (ec as IVersionableConformanceResource).Url, 
-				version = (ec as IVersionableConformanceResource).Version 
+				ResourceType = ec.TypeName, 
+				Canonical = (ec as IVersionableConformanceResource).Url, 
+				Version = (ec as IVersionableConformanceResource).Version 
 			}).ToList();
 			//var dependentCanonicals = DependencyChecker.ScanForCanonicals(packageContents.Union(downloadedContents), downloadedResources, r4b.Hl7.Fhir.Model.ModelInfo.ModelInspector);
 			//foreach (var dc in dependentCanonicals)

--- a/UploadFIG.Test/UploadFIG.Test.csproj
+++ b/UploadFIG.Test/UploadFIG.Test.csproj
@@ -17,10 +17,10 @@
     <PackageReference Include="Hl7.Fhir.R4B" Version="5.11.3" Aliases="r4b" />
     <PackageReference Include="Hl7.Fhir.R5" Version="5.11.3" Aliases="r5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="9.0.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.7.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.7.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="9.0.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.8.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.8.2" />
     <PackageReference Include="coverlet.collector" Version="3.2.0" />
 
     <PackageReference Include="Hl7.Fhir.Specification.Data.R4B" Version="5.11.3" />

--- a/UploadFIG/CanonicalDetails.cs
+++ b/UploadFIG/CanonicalDetails.cs
@@ -1,4 +1,5 @@
-﻿using Hl7.Fhir.Model;
+﻿using System.Text.Json.Serialization;
+using Hl7.Fhir.Model;
 
 namespace UploadFIG
 {
@@ -6,11 +7,21 @@ namespace UploadFIG
 	public class CanonicalDetails : IComparable<CanonicalDetails>
 	{
         public CanonicalDetails() { }
-		public string resourceType { get; set; }
-        public string canonical { get; set; }
-        public string version { get; set; }
-        public string status { get; set; }
-        public string name { get; set; }
+
+        [JsonPropertyName("resourceType")]
+        public string ResourceType { get; set; }
+
+        [JsonPropertyName("canonical")]
+        public string Canonical { get; set; }
+
+        [JsonPropertyName("version")]
+        public string Version { get; set; }
+
+        [JsonPropertyName("status")]
+        public string Status { get; set; }
+
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
 
         public Resource resource { get; set; }
 
@@ -20,9 +31,9 @@ namespace UploadFIG
 		{
 			if (other == null)
 				return -1;
-			int result = string.CompareOrdinal(canonical, other.canonical);
+			int result = string.CompareOrdinal(Canonical, other.Canonical);
 			if (result == 0)
-				result = string.CompareOrdinal(version, other.version);
+				result = string.CompareOrdinal(Version, other.Version);
 			return result;
 		}
 	}

--- a/UploadFIG/ExpressionValidator.cs
+++ b/UploadFIG/ExpressionValidator.cs
@@ -248,9 +248,9 @@ namespace UploadFIG
 			Canonical c = new Canonical(uri);
 			var cd = new CanonicalDetails()
 			{
-				canonical = c.Uri,
-				version = c.Version,
-				resourceType = "StructureDefinition",
+				Canonical = c.Uri,
+				Version = c.Version,
+				ResourceType = "StructureDefinition",
 			};
 			cd.requiredBy.Add(_resource);
 
@@ -261,7 +261,7 @@ namespace UploadFIG
 				var distinctVersionSources = matches.Select(m => ResourcePackageSource.PackageSourceVersion(m)).Distinct();
 				if (distinctVersionSources.Count() > 1 && _verbose)
 				{
-					Console.Write($"    Resolved {cd.canonical}|{cd.version} with ");
+					Console.Write($"    Resolved {cd.Canonical}|{cd.Version} with ");
 					ConsoleEx.Write(ConsoleColor.Yellow, ResourcePackageSource.PackageSourceVersion(useResource));
 					Console.WriteLine($" from {String.Join(", ", distinctVersionSources)}");
 				}

--- a/UploadFIG/PackageHelpers/PackageDetails.cs
+++ b/UploadFIG/PackageHelpers/PackageDetails.cs
@@ -39,15 +39,15 @@ namespace UploadFIG.PackageHelpers
 				foreach (var rc in RequiresCanonicals.Order())
 				{
 					if (rc.resource == null)
-						Console.WriteLine($"{tabPrefix}      - {rc.canonical}|{rc.version}");
+						Console.WriteLine($"{tabPrefix}      - {rc.Canonical}|{rc.Version}");
 					else if (rc.resource is IVersionableConformanceResource ivr)
 					{
 						var packageSource = ResourcePackageSource.PackageSourceVersion(ivr);
-						Console.WriteLine($"{tabPrefix}      + {rc.canonical}|{packageSource}");
+						Console.WriteLine($"{tabPrefix}      + {rc.Canonical}|{packageSource}");
 					}
 					else
 					{
-						Console.WriteLine($"{tabPrefix}      + {rc.canonical}|{rc.version}");
+						Console.WriteLine($"{tabPrefix}      + {rc.Canonical}|{rc.Version}");
 					}
 					if (debugRequiredByProps)
 					{

--- a/UploadFIG/Program.cs
+++ b/UploadFIG/Program.cs
@@ -284,7 +284,7 @@ namespace UploadFIG
 					var distinctVersionSources = matches.Select(m => ResourcePackageSource.PackageSourceVersion(m)).Distinct();
 					if (distinctVersionSources.Count() > 1 && settings.Verbose)
 					{
-						Console.Write($"    Resolved {canonicalUrl.canonical}|{canonicalUrl.version} with ");
+						Console.Write($"    Resolved {canonicalUrl.Canonical}|{canonicalUrl.Version} with ");
 						ConsoleEx.Write(ConsoleColor.Yellow, ResourcePackageSource.PackageSourceVersion(useResource));
 						Console.WriteLine($" from {String.Join(", ", distinctVersionSources)}");
 					}
@@ -683,20 +683,20 @@ namespace UploadFIG
 				{
 					dumpOutput.containedCanonicals.Add(new CanonicalDetails()
 					{
-						resourceType = (resource as Resource).TypeName,
-						canonical = resource.Url,
-						version = resource.Version,
-						status = resource.Status.GetLiteral(),
-						name = resource.Name,
+						ResourceType = (resource as Resource).TypeName,
+						Canonical = resource.Url,
+						Version = resource.Version,
+						Status = resource.Status.GetLiteral(),
+						Name = resource.Name,
 					});
 					// Console.WriteLine($"\t{resource.Url}\t{resource.Version}\t{resource.Status}\t{resource.Name}");
 				}
 				dumpOutput.externalCanonicalsRequired.AddRange(
 					externalCanonicals.Select(rc => new DependentResource()
 					{
-						resourceType = rc.resourceType,
-						canonical = rc.canonical,
-						version = rc.version,
+						resourceType = rc.ResourceType,
+						canonical = rc.Canonical,
+						version = rc.Version,
 					})
 					);
 				try
@@ -799,8 +799,8 @@ namespace UploadFIG
 			Queue<Bundle.EntryComponent> entries = new Queue<Bundle.EntryComponent>(alternativeOutputBundle.Entry);
 			var reOrderedList = new List<Bundle.EntryComponent>();
 			var definedCanonicals = new StringCollection();
-			definedCanonicals.AddRange(allUnresolvedCanonicals.Select(c => c.canonical).ToArray());
-			definedCanonicals.AddRange(allUnresolvedCanonicals.Select(c => $"{c.canonical}|{c.version}").ToArray());
+			definedCanonicals.AddRange(allUnresolvedCanonicals.Select(c => c.Canonical).ToArray());
+			definedCanonicals.AddRange(allUnresolvedCanonicals.Select(c => $"{c.Canonical}|{c.Version}").ToArray());
 			var futureCanonicals = new Dictionary<string, Resource>();
 			var lastEntry = alternativeOutputBundle.Entry.LastOrDefault();
 			while (entries.Any())
@@ -1114,8 +1114,8 @@ namespace UploadFIG
 					try
 					{
 						if (settings.Verbose)
-							Console.WriteLine($"Searching registry for {dc.resourceType} {dc.canonical}");
-						var r = await clientRegistry.SearchAsync(dc.resourceType, new[] { $"url={dc.canonical}" }, null, null, Hl7.Fhir.Rest.SummaryType.Data);
+							Console.WriteLine($"Searching registry for {dc.ResourceType} {dc.Canonical}");
+						var r = await clientRegistry.SearchAsync(dc.ResourceType, new[] { $"url={dc.Canonical}" }, null, null, Hl7.Fhir.Rest.SummaryType.Data);
 						if (r.Entry.Count > 1)
 						{
 							// Check if these are just more versions of the same thing, then to the canonical versioning thingy
@@ -1132,7 +1132,7 @@ namespace UploadFIG
 							resolvedResource.Meta?.Tag?.RemoveAll(t => t.Code == "SUBSETTED");
 							additionalResources.Add(resolvedResource);
 							// UploadFile(settings, clientFhir, resolvedResource);
-							unresolvableCanonicals.RemoveAll(uc => uc.canonical == dc.canonical);
+							unresolvableCanonicals.RemoveAll(uc => uc.Canonical == dc.Canonical);
 							indirectCanonicals.Add(dc);
 							dc.resource = resolvedResource;
 
@@ -1151,15 +1151,15 @@ namespace UploadFIG
 					}
 					catch (Exception ex)
 					{
-						System.Console.WriteLine($"Error searching for {dc.resourceType} {dc.canonical} at {settings.ExternalRegistry} {ex.Message}");
+						System.Console.WriteLine($"Error searching for {dc.ResourceType} {dc.Canonical} at {settings.ExternalRegistry} {ex.Message}");
 					}
 				}
 				// now perform another scan for their dependencies too
 				var initialCanonicals = additionalResources.Select(ec => new CanonicalDetails()
 				{
-					resourceType = ec.TypeName,
-					canonical = (ec as IVersionableConformanceResource).Url,
-					version = (ec as IVersionableConformanceResource).Version
+					ResourceType = ec.TypeName,
+					Canonical = (ec as IVersionableConformanceResource).Url,
+					Version = (ec as IVersionableConformanceResource).Version
 				}).ToList();
 				var dependentCanonicals = depChecker.ScanForCanonicals(initialCanonicals.Union(externalCanonicals), additionalResources);
 				foreach (var dc in dependentCanonicals)
@@ -1167,8 +1167,8 @@ namespace UploadFIG
 					try
 					{
 						if (settings.Verbose)
-							Console.WriteLine($"Searching registry for {dc.resourceType} {dc.canonical}");
-						var r = clientRegistry.Search(dc.resourceType, new[] { $"url={dc.canonical}" }, null, null, Hl7.Fhir.Rest.SummaryType.Data);
+							Console.WriteLine($"Searching registry for {dc.ResourceType} {dc.Canonical}");
+						var r = clientRegistry.Search(dc.ResourceType, new[] { $"url={dc.Canonical}" }, null, null, Hl7.Fhir.Rest.SummaryType.Data);
 						if (r.Entry.Count > 1)
 						{
 							// Check if these are just more versions of the same thing, then to the canonical versioning thingy
@@ -1184,7 +1184,7 @@ namespace UploadFIG
 							resolvedResource.Meta?.Tag?.RemoveAll(t => t.Code == "SUBSETTED");
 							additionalResources.Insert(0, resolvedResource); // put dependencies at the start of the list
 																			 // UploadFile(settings, clientFhir, resolvedResource);
-							unresolvableCanonicals.RemoveAll(uc => uc.canonical == dc.canonical);
+							unresolvableCanonicals.RemoveAll(uc => uc.Canonical == dc.Canonical);
 							indirectCanonicals.Add(dc);
 							dc.resource = resolvedResource;
 
@@ -1203,7 +1203,7 @@ namespace UploadFIG
 					}
 					catch (Exception ex)
 					{
-						System.Console.WriteLine($"Error searching for {dc.resourceType} {dc.canonical} at {settings.ExternalRegistry} {ex.Message}");
+						System.Console.WriteLine($"Error searching for {dc.ResourceType} {dc.Canonical} at {settings.ExternalRegistry} {ex.Message}");
 					}
 				}
 
@@ -1441,9 +1441,9 @@ namespace UploadFIG
 		private static void ReportCanonicalDetailsToConsole(Settings settings, IEnumerable<CanonicalDetails> list)
 		{
 			Console.WriteLine("\tResource Type\tCanonical Url\tVersion\tPackage Source");
-			foreach (var details in list.OrderBy(f => $"{f.canonical}|{f.version}"))
+			foreach (var details in list.OrderBy(f => $"{f.Canonical}|{f.Version}"))
 			{
-				Console.Write($"\t{details.resourceType}\t{details.canonical}\t{details.version}");
+				Console.Write($"\t{details.ResourceType}\t{details.Canonical}\t{details.Version}");
 				if (details.resource?.HasAnnotation<ResourcePackageSource>() == true)
 				{
 					var sourceDetails = details.resource.Annotation<ResourcePackageSource>();
@@ -1481,7 +1481,7 @@ namespace UploadFIG
 			Dictionary<string, CanonicalDetails> mergedCDs = new ();
 			foreach (var cd in unresolvableCanonicals)
 			{
-				var key = $"{cd.canonical}|{cd.version}";
+				var key = $"{cd.Canonical}|{cd.Version}";
 				if (!mergedCDs.ContainsKey(key))
 				{
 					mergedCDs.Add(key, cd);
@@ -1490,11 +1490,11 @@ namespace UploadFIG
 				{
 					var newCd = new CanonicalDetails 
 					{
-						canonical = cd.canonical,
-						name = cd.name,
-						version = cd.version,
-						resourceType = cd.resourceType,
-						status = cd.status,
+						Canonical = cd.Canonical,
+						Name = cd.Name,
+						Version = cd.Version,
+						ResourceType = cd.ResourceType,
+						Status = cd.Status,
 					};
 					newCd.requiredBy.AddRange(mergedCDs[key].requiredBy);
 					foreach (var req in cd.requiredBy)

--- a/UploadFIG/Program.cs
+++ b/UploadFIG/Program.cs
@@ -81,6 +81,7 @@ namespace UploadFIG
                 new Option<string>(new string[]{ "-pv", "--packageVersion"}, () => settings.PackageVersion, "The version of the Package to upload (from the HL7 FHIR Package Registry)"),
                 new Option<List<string>>(new string[]{ "-r", "--resourceTypes"}, () => settings.ResourceTypes, "Which resource types should be processed by the uploader"),
                 new Option<List<string>>(new string[]{ "-sf", "--selectFiles"}, () => settings.SelectFiles, "Only process these selected files\r\n(e.g. package/SearchParameter-valueset-extensions-ValueSet-end.json)"),
+                new Option<List<string>>(new string[]{ "-ap", "--additionalPackages"}, () => settings.AdditionalPackages, "Set of additional packages to include in the processing\r\nThese will be processes as though they are dependencies of the root package"),
                 new Option<List<string>>(new string[]{ "-if", "--ignoreFiles" }, () => settings.IgnoreFiles, "Any specific files that should be ignored/skipped when processing the package"),
                 new Option<List<string>>(new string[]{ "-ic", "--ignoreCanonicals" }, () => settings.IgnoreCanonicals, "Any specific Canonical URls that should be ignored/skipped when processing the package and resource dependencies"),
                 new Option<List<string>>(new string[]{ "-ip", "--ignorePackages" }, () => settings.IgnorePackages, "While loading in dependencies, ignore these versioned packages. e.g. us.nlm.vsac|0.18.0" ),
@@ -242,7 +243,8 @@ namespace UploadFIG
 			var packageCache = new TempPackageCache();
 			packageCache.RegisterPackage(manifest.Name, manifest.Version, sourceStream);
 			var pd = PackageReader.ReadPackageIndexDetails(sourceStream, packageCache, settings.IgnorePackages);
-			var depChecker = new DependencyChecker(settings, fhirVersion.Value, versionAgnosticProcessor.ModelInspector, packageCache);
+            PackageReader.ReadAdditionalPackageIndexDetails(pd, settings.AdditionalPackages, packageCache, settings.IgnorePackages);
+            var depChecker = new DependencyChecker(settings, fhirVersion.Value, versionAgnosticProcessor.ModelInspector, packageCache);
 
 			// Validate the settings files to skip (ensuring that there are no files that are not in the package)
 			ValidateFileInclusionAndExclusionSettings(settings, pd);

--- a/UploadFIG/Settings.cs
+++ b/UploadFIG/Settings.cs
@@ -51,6 +51,12 @@ namespace UploadFIG
         public List<string> SelectFiles { get; set; }
 
 		/// <summary>
+        /// Set of additional packages to include in the processing
+        /// These will be processes as though they are dependencies of the root package
+        /// </summary>
+        public List<string> AdditionalPackages { get; set; }
+
+        /// <summary>
 		/// Any specific files that should be ignored/skipped when processing the package
 		/// (Is used as a filter on the root package only)
 		/// </summary>


### PR DESCRIPTION
Add the `-ap` or `--AdditionalPackages` flag to include additional packages in the processing<br/>
  *These will be processed as though they are dependencies of the root package.*
  *This is useful if you want to include additional packages that are not dependencies of the root package*
  *Particularly to resolve resources from a newer terminology.hl7.org or hl7.fhir.uv.extensions package version*