### PR TITLE
Refinements to Dependency Scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Options:
   -pv, --packageVersion <packageVersion>                     The version of the Package to upload (from the HL7 FHIR Package
                                                              Registry)
   -r, --resourceTypes <resourceTypes>                        Which resource types should be processed by the uploader 
+                                                             Note that `*` can be used to permit ALL types to be uploaded
                                                              [default: StructureDefinition|ValueSet|CodeSystem|Questionnaire
                                                              |SearchParameter|ConceptMap|StructureMap|Library]
   -sf, --selectFiles <selectFiles>                           Only process these selected files

--- a/README.md
+++ b/README.md
@@ -466,6 +466,12 @@ using the `-pcv` Patch Canonical Versions flag
 
 ## Change history
 
+### 19 March 2025
+* Issue [#21](https://github.com/brianpos/UploadFIG/issues/21) Resource Types `*` to not filter out any types (default is a subset of canonicals)
+* Better handling of tree shaking dependent resources that aren't scoped in (as newer versions are already in scope)
+* Don't test the types in a logical model as they aren't FHIR types.
+* Fixed issue [#24](https://github.com/brianpos/UploadFIG/issues/24) Obscure error when package doesn't define the FHIR version
+
 ### 6 March 2025
 * Add the `-ap` or `--AdditionalPackages` flag to include additional packages in the processing<br/>
   *These will be processed as though they are dependencies of the root package.*

--- a/README.md
+++ b/README.md
@@ -472,6 +472,7 @@ using the `-pcv` Patch Canonical Versions flag
 * Better handling of tree shaking dependent resources that aren't scoped in (as newer versions are already in scope)
 * Don't test the types in a logical model as they aren't FHIR types.
 * Fixed issue [#24](https://github.com/brianpos/UploadFIG/issues/24) Obscure error when package doesn't define the FHIR version
+* Report an error if the package dependency can't be loaded (e.g. requesting `current` version)
 
 ### 6 March 2025
 * Add the `-ap` or `--AdditionalPackages` flag to include additional packages in the processing<br/>

--- a/UploadFIG.Test/CheckImplementationGuides.cs
+++ b/UploadFIG.Test/CheckImplementationGuides.cs
@@ -7,6 +7,7 @@ using System.Text;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Utility;
 using Newtonsoft.Json;
+using System.Runtime.CompilerServices;
 
 namespace UploadFIG.Test
 {
@@ -37,9 +38,9 @@ namespace UploadFIG.Test
             Console.WriteLine(_sb);
         }
 
-        public async Task CheckTestResults(string testName, Program.Result results)
+        public async Task CheckTestResults(Program.Result results, [CallerMemberName] string caller = "")
         {
-            string testResultPath = Path.Combine(System.IO.Path.GetTempPath(), "UploadFIG", "TestResult", testName);
+            string testResultPath = Path.Combine(System.IO.Path.GetTempPath(), "UploadFIG", "TestResult", caller);
 
             // Check the console output
             if (File.Exists(testResultPath + ".txt"))
@@ -48,7 +49,13 @@ namespace UploadFIG.Test
                 System.IO.File.WriteAllText(testResultPath + "2.txt", _sb.ToString());
 
                 var expectedResult = File.ReadAllText(testResultPath + ".txt");
-                Assert.AreEqual(expectedResult, _sb.ToString());
+                var actualResult = _sb.ToString();
+                // filter the result strings to remove the `Package cache folder size:` from the value
+                var expectedLines = expectedResult.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+                var actualLines = actualResult.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+                var expectedFiltered = string.Join(Environment.NewLine, expectedLines.Where(line => !line.StartsWith("Package cache folder size:")));
+                var actualFiltered = string.Join(Environment.NewLine, actualLines.Where(line => !line.StartsWith("Package cache folder size:")));
+                Assert.IsTrue(expectedFiltered == actualFiltered, "Console Output changed");
             }
             else
             {
@@ -153,6 +160,7 @@ namespace UploadFIG.Test
 			});
             var result = await Program.UploadPackageInternal(settings);
             Assert.AreEqual(0, result.Value);
+            await CheckTestResults(result);
 
 			Assert.AreEqual(4518, result.successes);
 			Assert.AreEqual(10, result.failures);
@@ -173,6 +181,7 @@ namespace UploadFIG.Test
 			});
             var result = await Program.UploadPackageInternal(settings);
             Assert.AreEqual(0, result.Value);
+            await CheckTestResults(result);
 
 			Assert.AreEqual(4546, result.successes);
 			Assert.AreEqual(11, result.failures);
@@ -191,10 +200,8 @@ namespace UploadFIG.Test
                 ResourceTypes = Program.defaultResourceTypes.ToList(),
             };
             var result = await Program.UploadPackageInternal(settings);
-
             Assert.AreEqual(0, result.Value);
-
-            await CheckTestResults("sdc300", result);
+            await CheckTestResults(result);
 
 			Assert.AreEqual(125, result.successes);
 			Assert.AreEqual(0, result.failures);
@@ -218,10 +225,11 @@ namespace UploadFIG.Test
             });
             var result = await Program.UploadPackageInternal(settings);
             Assert.AreEqual(0, result.Value);
+            await CheckTestResults(result);
 
 			Assert.AreEqual(161, result.successes);
 			Assert.AreEqual(0, result.failures);
-			Assert.AreEqual(4, result.validationErrors);
+			Assert.AreEqual(6, result.validationErrors);
 		}
 
 		[TestMethod]
@@ -240,6 +248,7 @@ namespace UploadFIG.Test
             });
             var result = await Program.UploadPackageInternal(settings);
             Assert.AreEqual(0, result.Value);
+            await CheckTestResults(result);
 
 			Assert.AreEqual(142, result.successes);
 			Assert.AreEqual(1, result.failures);
@@ -261,10 +270,11 @@ namespace UploadFIG.Test
             });
             var result = await Program.UploadPackageInternal(settings);
             Assert.AreEqual(0, result.Value);
+            await CheckTestResults(result);
 
-			Assert.AreEqual(209, result.successes);
+            Assert.AreEqual(215, result.successes);
 			Assert.AreEqual(0, result.failures);
-			Assert.AreEqual(6, result.validationErrors);
+			Assert.AreEqual(1, result.validationErrors);
         }
 
 
@@ -282,6 +292,7 @@ namespace UploadFIG.Test
 			});
             var result = await Program.UploadPackageInternal(settings);
             Assert.AreEqual(0, result.Value);
+            await CheckTestResults(result);
 		}
 
 		[TestMethod]
@@ -297,6 +308,7 @@ namespace UploadFIG.Test
 			});
             var result = await Program.UploadPackageInternal(settings);
             Assert.AreEqual(0, result.Value);
+            await CheckTestResults(result);
 		}
 
 		[TestMethod]
@@ -312,6 +324,7 @@ namespace UploadFIG.Test
 			});
             var result = await Program.UploadPackageInternal(settings);
             Assert.AreEqual(0, result.Value);
+            await CheckTestResults(result);
 		}
 
 		[TestMethod]
@@ -329,6 +342,7 @@ namespace UploadFIG.Test
             });
             var result = await Program.UploadPackageInternal(settings);
             Assert.AreEqual(0, result.Value);
+            await CheckTestResults(result);
         }
 
         [TestMethod]
@@ -350,6 +364,7 @@ namespace UploadFIG.Test
             });
             var result = await Program.UploadPackageInternal(settings);
             Assert.AreEqual(0, result.Value);
+            await CheckTestResults(result);
 
 			Assert.AreEqual(54, result.successes);
 			Assert.AreEqual(0, result.failures);
@@ -370,6 +385,7 @@ namespace UploadFIG.Test
             });
             var result = await Program.UploadPackageInternal(settings);
             Assert.AreEqual(0, result.Value);
+            await CheckTestResults(result);
 
 			Assert.AreEqual(215, result.successes);
 			Assert.AreEqual(0, result.failures);
@@ -392,8 +408,9 @@ namespace UploadFIG.Test
             var result = await Program.UploadPackageInternal(settings);
 
             Assert.AreEqual(0, result.Value);
+            await CheckTestResults(result);
 
-			Assert.AreEqual(268, result.successes);
+            Assert.AreEqual(209, result.successes);
 			Assert.AreEqual(0, result.failures);
 			Assert.AreEqual(6, result.validationErrors);
 		}
@@ -412,8 +429,9 @@ namespace UploadFIG.Test
 			});
             var result = await Program.UploadPackageInternal(settings);
             Assert.AreEqual(0, result.Value);
+            await CheckTestResults(result);
 
-			Assert.AreEqual(226, result.successes);
+            Assert.AreEqual(224, result.successes);
 			Assert.AreEqual(0, result.failures);
 			Assert.AreEqual(3, result.validationErrors); // the search parameter 'special' type creates an info message
 		}
@@ -421,20 +439,22 @@ namespace UploadFIG.Test
 		[TestMethod]
         public async Task CheckMcode()
         {
-            // "commandLineArgs": "-t -pid hl7.fhir.us.mcode -odf c:/temp/uploadfig-dump.json"
-            string outputFile = "c:\\temp\\uploadfig-dump-mcode.json";
             var settings = ParseArguments(new[]
             {
                 "-t",
 				"-vq",
+				"--includeReferencedDependencies",
 				"--includeExamples",
 				"-pid", "hl7.fhir.us.mcode",
-                "-odf", outputFile,
+                "-pv", "4.0.0",
+				// "-s", "https://hl7.org/fhir/us/mcode/STU4/package.tgz",
+				"-pcv",
             });
             var result = await Program.UploadPackageInternal(settings);
             Assert.AreEqual(0, result.Value);
+            await CheckTestResults(result);
 
-			Assert.AreEqual(103, Program.successes);
+            Assert.AreEqual(306, result.successes);
 			Assert.AreEqual(0, result.failures);
 			Assert.AreEqual(0, result.validationErrors);
 		}
@@ -456,10 +476,8 @@ namespace UploadFIG.Test
                 // SelectFiles = ["package/StructureDefinition-au-core-patient.json"],
             };
             var result = await Program.UploadPackageInternal(settings);
-
             Assert.AreEqual(0, result.Value);
-
-            await CheckTestResults("aucore100", result);
+            await CheckTestResults(result);
 
    //         // "commandLineArgs": "-d https://localhost:44391 -pid hl7.fhir.au.core -fd -pdv false"
    //         string outputFile = "c:\\temp\\uploadfig-dump-aucore.json";
@@ -486,21 +504,26 @@ namespace UploadFIG.Test
 		[TestMethod]
         public async Task CheckAuCoreCI()
         {
-            // "commandLineArgs": "-d https://localhost:44391 -pid hl7.fhir.au.core -fd -pdv false"
-            string outputFile = "c:\\temp\\uploadfig-dump-aucore.json";
             var settings = ParseArguments(new[]
             {
                 "-t",
 				"-vq",
-				"--includeReferencedDependencies",
+				// "--includeReferencedDependencies",
 				"--includeExamples",
 				"-s", "https://build.fhir.org/ig/hl7au/au-fhir-core/package.tgz",
-                "-odf", outputFile,
+
+                // Additional Packages to define which "current" to use
+                "-ap", "hl7.fhir.au.base|5.1.0-preview",
+                "-ap", "hl7.fhir.uv.ipa|1.0.0",
+
+                // resolve the NCTS content
+                // "-reg", "https://api.healthterminologies.gov.au/integration/R4/fhir",
             });
             var result = await Program.UploadPackageInternal(settings);
             Assert.AreEqual(0, result.Value);
+            await CheckTestResults(result);
 
-			Assert.AreEqual(26, result.successes);
+            Assert.AreEqual(27, result.successes);
 			Assert.AreEqual(0, result.failures);
 			Assert.AreEqual(0, result.validationErrors);
 		}
@@ -523,8 +546,9 @@ namespace UploadFIG.Test
             });
             var result = await Program.UploadPackageInternal(settings);
             Assert.AreEqual(0, result.Value);
+            await CheckTestResults(result);
 
-			Assert.AreEqual(138, result.successes);
+            Assert.AreEqual(146, result.successes);
 			Assert.AreEqual(0, result.failures);
 			Assert.AreEqual(0, result.validationErrors);
         }
@@ -533,19 +557,18 @@ namespace UploadFIG.Test
         public async Task CheckAuBaseCI()
         {
             // "commandLineArgs": "-d https://localhost:44391 -pid hl7.fhir.au.base -fd -pdv false"
-            string outputFile = "c:\\temp\\uploadfig-dump-aubase.json";
             var settings = ParseArguments(new[]
             {
                 "-t",
 				"-vq",
 				"--includeExamples",
 				"-pid", "hl7.fhir.au.base",
-                "-odf", outputFile,
             });
             var result = await Program.UploadPackageInternal(settings);
             Assert.AreEqual(0, result.Value);
+            await CheckTestResults(result);
 
-			Assert.AreEqual(138, result.successes);
+            Assert.AreEqual(146, result.successes);
 			Assert.AreEqual(0, result.failures);
 			Assert.AreEqual(0, result.validationErrors);
         }
@@ -566,6 +589,7 @@ namespace UploadFIG.Test
             });
             var result = await Program.UploadPackageInternal(settings);
             Assert.AreEqual(0, result.Value);
+            await CheckTestResults(result);
 
 			Assert.AreEqual(42, result.successes);
 			Assert.AreEqual(0, result.failures);
@@ -589,6 +613,7 @@ namespace UploadFIG.Test
             });
             var result = await Program.UploadPackageInternal(settings);
             Assert.AreEqual(0, result.Value);
+            await CheckTestResults(result);
 
 			Assert.AreEqual(42, result.successes);
 			Assert.AreEqual(0, result.failures);
@@ -612,6 +637,7 @@ namespace UploadFIG.Test
             });
             var result = await Program.UploadPackageInternal(settings);
             Assert.AreEqual(0, result.Value);
+            await CheckTestResults(result);
 
 			Assert.AreEqual(20, result.successes);
 			Assert.AreEqual(0, result.failures);
@@ -657,6 +683,7 @@ namespace UploadFIG.Test
             });
             var result = await Program.UploadPackageInternal(settings);
             Assert.AreEqual(0, result.Value);
+            await CheckTestResults(result);
 
 			Assert.AreEqual(55, result.successes);
 			Assert.AreEqual(0, result.failures);
@@ -687,10 +714,11 @@ namespace UploadFIG.Test
             });
             var result = await Program.UploadPackageInternal(settings);
             Assert.AreEqual(0, result.Value);
+            await CheckTestResults(result);
 
-			Assert.AreEqual(226, result.successes);
+            Assert.AreEqual(211, result.successes);
 			Assert.AreEqual(0, result.failures);
-			Assert.AreEqual(0, result.validationErrors);
+			Assert.AreEqual(2, result.validationErrors);
 		}
 	}
 }

--- a/UploadFIG.Test/CheckImplementationGuides.cs
+++ b/UploadFIG.Test/CheckImplementationGuides.cs
@@ -27,10 +27,6 @@ namespace UploadFIG.Test
             _writer = new StringWriter(_sb);
             _rawWriter = Console.Out;
             Console.SetOut(_writer);
-
-            Program.successes = 0;
-            Program.failures = 0;
-            Program.validationErrors = 0;
         }
 
         [TestCleanup]
@@ -125,7 +121,7 @@ namespace UploadFIG.Test
 		{
 			// "commandLineArgs": "-d https://localhost:44391 -pid hl7.fhir.us.sdoh-clinicalcare -fd -pdv false --verbose"
 			string outputFile = "c:\\temp\\uploadfig-dump-fmg.json";
-			var result = await Program.Main(new[]
+			var settings = ParseArguments(new[]
 			{
 				"-t",
 				"-vq",
@@ -136,45 +132,38 @@ namespace UploadFIG.Test
                 
                 "-s", "https://build.fhir.org/ig/HL7/cqf-recommendations/package.tgz",
 			});
-			Assert.AreEqual(0, result);
+            var result = await Program.UploadPackageInternal(settings);
+            Assert.AreEqual(0, result.Value);
 
-			string json = System.IO.File.ReadAllText(outputFile);
-			var output = System.Text.Json.JsonSerializer.Deserialize<OutputDependenciesFile>(json);
-			Bundle bun = new Bundle();
-
-			Console.WriteLine();
-			Console.WriteLine("--------------------------------------");
-			Console.WriteLine("Recursively Scanning Dependencies...");
-			PrepareDependantPackage.RecursivelyScanPackageForCanonicals(output, bun);
-
-			Assert.AreEqual(0, Program.failures);
-			Assert.AreEqual(0, Program.validationErrors);
+			Assert.AreEqual(0, result.failures);
+			Assert.AreEqual(0, result.validationErrors);
 		}
 
 		[TestMethod]
 		public async Task CheckFhirCoreR4()
 		{
 			string outputFile = "c:\\temp\\uploadfig-dump-r4core.json";
-			var result = await Program.Main(new[]
+			var settings = ParseArguments(new[]
 			{
 				"-t",
 				"-vq",
-				"--includeExamples",
+				// "--includeExamples",
 				"-pid", "hl7.fhir.r4.core",
 				"-odf", outputFile,
 			});
-			Assert.AreEqual(0, result);
+            var result = await Program.UploadPackageInternal(settings);
+            Assert.AreEqual(0, result.Value);
 
-			Assert.AreEqual(4518, Program.successes);
-			Assert.AreEqual(10, Program.failures);
-			Assert.AreEqual(66, Program.validationErrors);
+			Assert.AreEqual(4518, result.successes);
+			Assert.AreEqual(10, result.failures);
+			Assert.AreEqual(69, result.validationErrors);
 		}
 
 		[TestMethod]
 		public async Task CheckFhirExamplesR4()
 		{
 			string outputFile = "c:\\temp\\uploadfig-dump-r4examples.json";
-			var result = await Program.Main(new[]
+			var settings = ParseArguments(new[]
 			{
 				"-t",
 				"-vq",
@@ -182,11 +171,12 @@ namespace UploadFIG.Test
 				"-pid", "hl7.fhir.r4.examples",
 				"-odf", outputFile,
 			});
-			Assert.AreEqual(0, result);
+            var result = await Program.UploadPackageInternal(settings);
+            Assert.AreEqual(0, result.Value);
 
-			Assert.AreEqual(4546, Program.successes);
-			Assert.AreEqual(11, Program.failures);
-			Assert.AreEqual(69, Program.validationErrors);
+			Assert.AreEqual(4546, result.successes);
+			Assert.AreEqual(11, result.failures);
+			Assert.AreEqual(69, result.validationErrors);
 		}
 
 		[TestMethod]
@@ -206,16 +196,16 @@ namespace UploadFIG.Test
 
             await CheckTestResults("sdc300", result);
 
-			Assert.AreEqual(125, Program.successes);
-			Assert.AreEqual(0, Program.failures);
-			Assert.AreEqual(15, Program.validationErrors);
+			Assert.AreEqual(125, result.successes);
+			Assert.AreEqual(0, result.failures);
+			Assert.AreEqual(15, result.validationErrors);
 		}
 
 		[TestMethod]
         public async Task CheckSDC_CI()
         {
             string outputFile = "c:\\temp\\uploadfig-dump-sdc-ci.json";
-            var result = await Program.Main(new[]
+            var settings = ParseArguments(new[]
             {
                 "-t",
                 "-vq",
@@ -226,11 +216,12 @@ namespace UploadFIG.Test
 				"-odf", outputFile,
                 // "--verbose",
             });
-            Assert.AreEqual(0, result);
+            var result = await Program.UploadPackageInternal(settings);
+            Assert.AreEqual(0, result.Value);
 
-			Assert.AreEqual(161, Program.successes);
-			Assert.AreEqual(0, Program.failures);
-			Assert.AreEqual(4, Program.validationErrors);
+			Assert.AreEqual(161, result.successes);
+			Assert.AreEqual(0, result.failures);
+			Assert.AreEqual(4, result.validationErrors);
 		}
 
 		[TestMethod]
@@ -238,7 +229,7 @@ namespace UploadFIG.Test
         {
             // "commandLineArgs": "-d https://localhost:44391 -pid hl7.fhir.us.core -pv 3.1.1 -pdv false"
             string outputFile = "c:\\temp\\uploadfig-dump-uscore311.json";
-            var result = await Program.Main(new[]
+            var settings = ParseArguments(new[]
             {
                 "-t",
 				"-vq",
@@ -247,11 +238,12 @@ namespace UploadFIG.Test
                 "-pv", "3.1.1",
                 "-odf", outputFile,
             });
-            Assert.AreEqual(0, result);
+            var result = await Program.UploadPackageInternal(settings);
+            Assert.AreEqual(0, result.Value);
 
-			Assert.AreEqual(142, Program.successes);
-			Assert.AreEqual(1, Program.failures);
-			Assert.AreEqual(3, Program.validationErrors);
+			Assert.AreEqual(142, result.successes);
+			Assert.AreEqual(1, result.failures);
+			Assert.AreEqual(3, result.validationErrors);
         }
 
         [TestMethod]
@@ -259,7 +251,7 @@ namespace UploadFIG.Test
         {
             // "commandLineArgs": "-d https://localhost:44391 -pid hl7.fhir.us.core -pv 6.0.0-ballot -fd -pdv false"
             string outputFile = "c:\\temp\\uploadfig-dump-uscore.json";
-            var result = await Program.Main(new[]
+            var settings = ParseArguments(new[]
             {
                 "-t",
 				"-vq",
@@ -267,11 +259,12 @@ namespace UploadFIG.Test
 				"-pid", "hl7.fhir.us.core",
                 "-odf", outputFile,
             });
-            Assert.AreEqual(0, result);
+            var result = await Program.UploadPackageInternal(settings);
+            Assert.AreEqual(0, result.Value);
 
-			Assert.AreEqual(209, Program.successes);
-			Assert.AreEqual(0, Program.failures);
-			Assert.AreEqual(6, Program.validationErrors);
+			Assert.AreEqual(209, result.successes);
+			Assert.AreEqual(0, result.failures);
+			Assert.AreEqual(6, result.validationErrors);
         }
 
 
@@ -279,7 +272,7 @@ namespace UploadFIG.Test
 		public async Task CheckExtensionsRelease()
 		{
 			string outputFile = "c:\\temp\\uploadfig-dump-extensions.json";
-			var result = await Program.Main(new[]
+			var settings = ParseArguments(new[]
 			{
 				"-t",
 				"-vq",
@@ -287,42 +280,45 @@ namespace UploadFIG.Test
 				"-s", "https://hl7.org/fhir/extensions/package.tgz",
 				"-odf", outputFile,
 			});
-			Assert.AreEqual(0, result);
+            var result = await Program.UploadPackageInternal(settings);
+            Assert.AreEqual(0, result.Value);
 		}
 
 		[TestMethod]
 		public async Task CheckExtensionsCiR4()
 		{
-			var result = await Program.Main(new[]
+			var settings = ParseArguments(new[]
 			{
 				"-t",
 				"-vq",
 				"--includeExamples",
-				// "-s", "https://build.fhir.org/ig/HL7/fhir-extensions/hl7.fhir.uv.extensions.r4.tgz",
-				"-s", @"C:\Users\brianpo\Downloads\hl7.fhir.uv.extensions.r4 (3).tgz"
+				"-s", "https://build.fhir.org/ig/HL7/fhir-extensions/hl7.fhir.uv.extensions.r4.tgz",
+				// "-s", @"C:\Users\brianpo\Downloads\hl7.fhir.uv.extensions.r4 (3).tgz"
 			});
-			Assert.AreEqual(0, result);
+            var result = await Program.UploadPackageInternal(settings);
+            Assert.AreEqual(0, result.Value);
 		}
 
 		[TestMethod]
 		public async Task CheckExtensionsCiR4B()
 		{
-			var result = await Program.Main(new[]
+			var settings = ParseArguments(new[]
 			{
 				"-t",
 				"-vq",
 				"--includeExamples",
-				// "-s", "https://build.fhir.org/ig/HL7/fhir-extensions/hl7.fhir.uv.extensions.r4b.tgz",
-				"-s", @"C:\Users\brianpo\Downloads\hl7.fhir.uv.extensions.r4b (2).tgz"
+				"-s", "https://build.fhir.org/ig/HL7/fhir-extensions/branches/2025-03-gg-r4b/hl7.fhir.uv.extensions.r4b.tgz",
+				// "-s", @"C:\Users\brianpo\Downloads\hl7.fhir.uv.extensions.r4b (2).tgz"
 			});
-			Assert.AreEqual(0, result);
+            var result = await Program.UploadPackageInternal(settings);
+            Assert.AreEqual(0, result.Value);
 		}
 
 		[TestMethod]
         public async Task CheckExtensionsCI()
         {
             string outputFile = "c:\\temp\\uploadfig-dump-extensions.json";
-            var result = await Program.Main(new[]
+            var settings = ParseArguments(new[]
             {
                 "-t",
 				"-vq",
@@ -331,14 +327,15 @@ namespace UploadFIG.Test
 				"-s", "C:/git/hl7/fhir-extensions/output/package.tgz",
 				"-odf", outputFile,
             });
-            Assert.AreEqual(0, result);
+            var result = await Program.UploadPackageInternal(settings);
+            Assert.AreEqual(0, result.Value);
         }
 
         [TestMethod]
         public async Task CheckAuSmartFormsCI()
         {
             string outputFile = "c:\\temp\\uploadfig-dump-au-smartforms.json";
-            var result = await Program.Main(new[]
+            var settings = ParseArguments(new[]
             {
                 "-t",
 				"-vq",
@@ -351,18 +348,19 @@ namespace UploadFIG.Test
                 // "-sf", "package/SearchParameter-valueset-extensions-ValueSet-end.json",
                 // "--verbose",
             });
-            Assert.AreEqual(0, result);
+            var result = await Program.UploadPackageInternal(settings);
+            Assert.AreEqual(0, result.Value);
 
-			Assert.AreEqual(54, Program.successes);
-			Assert.AreEqual(0, Program.failures);
-			Assert.AreEqual(0, Program.validationErrors);
+			Assert.AreEqual(54, result.successes);
+			Assert.AreEqual(0, result.failures);
+			Assert.AreEqual(0, result.validationErrors);
 		}
 
 		[TestMethod]
         public async Task CheckUsCoreCI()
         {
             string outputFile = "c:\\temp\\uploadfig-dump-uscore.json";
-            var result = await Program.Main(new[]
+            var settings = ParseArguments(new[]
             {
                 "-t",
 				"-vq",
@@ -370,11 +368,12 @@ namespace UploadFIG.Test
 				"-s", "https://build.fhir.org/ig/HL7/US-Core/package.tgz",
                 "-odf", outputFile,
             });
-            Assert.AreEqual(0, result);
+            var result = await Program.UploadPackageInternal(settings);
+            Assert.AreEqual(0, result.Value);
 
-			Assert.AreEqual(215, Program.successes);
-			Assert.AreEqual(0, Program.failures);
-			Assert.AreEqual(1, Program.validationErrors);
+			Assert.AreEqual(215, result.successes);
+			Assert.AreEqual(0, result.failures);
+			Assert.AreEqual(1, result.validationErrors);
 		}
 
 		[TestMethod]
@@ -403,7 +402,7 @@ namespace UploadFIG.Test
 		public async Task CheckUsNDH_CI()
 		{
 			string outputFile = "c:\\temp\\uploadfig-dump-uscore.json";
-			var result = await Program.Main(new[]
+			var settings = ParseArguments(new[]
 			{
 				"-t",
 				"-vq",
@@ -411,11 +410,12 @@ namespace UploadFIG.Test
 				"-s", "http://build.fhir.org/ig/HL7/fhir-us-ndh/package.tgz",
 				"-odf", outputFile,
 			});
-			Assert.AreEqual(0, result);
+            var result = await Program.UploadPackageInternal(settings);
+            Assert.AreEqual(0, result.Value);
 
-			Assert.AreEqual(238, Program.successes);
-			Assert.AreEqual(0, Program.failures);
-			Assert.AreEqual(1, Program.validationErrors); // the search parameter 'special' type creates an info message
+			Assert.AreEqual(226, result.successes);
+			Assert.AreEqual(0, result.failures);
+			Assert.AreEqual(3, result.validationErrors); // the search parameter 'special' type creates an info message
 		}
 
 		[TestMethod]
@@ -423,7 +423,7 @@ namespace UploadFIG.Test
         {
             // "commandLineArgs": "-t -pid hl7.fhir.us.mcode -odf c:/temp/uploadfig-dump.json"
             string outputFile = "c:\\temp\\uploadfig-dump-mcode.json";
-            var result = await Program.Main(new[]
+            var settings = ParseArguments(new[]
             {
                 "-t",
 				"-vq",
@@ -431,11 +431,12 @@ namespace UploadFIG.Test
 				"-pid", "hl7.fhir.us.mcode",
                 "-odf", outputFile,
             });
-            Assert.AreEqual(0, result);
+            var result = await Program.UploadPackageInternal(settings);
+            Assert.AreEqual(0, result.Value);
 
 			Assert.AreEqual(103, Program.successes);
-			Assert.AreEqual(0, Program.failures);
-			Assert.AreEqual(1, Program.validationErrors);
+			Assert.AreEqual(0, result.failures);
+			Assert.AreEqual(0, result.validationErrors);
 		}
 
 		[TestMethod]
@@ -477,9 +478,9 @@ namespace UploadFIG.Test
 			//});
    //         Assert.AreEqual(0, result);
 
-			Assert.AreEqual(132, Program.successes);
-			Assert.AreEqual(0, Program.failures);
-			Assert.AreEqual(14, Program.validationErrors);
+			Assert.AreEqual(132, result.successes);
+			Assert.AreEqual(0, result.failures);
+			Assert.AreEqual(14, result.validationErrors);
 		}
 
 		[TestMethod]
@@ -487,7 +488,7 @@ namespace UploadFIG.Test
         {
             // "commandLineArgs": "-d https://localhost:44391 -pid hl7.fhir.au.core -fd -pdv false"
             string outputFile = "c:\\temp\\uploadfig-dump-aucore.json";
-            var result = await Program.Main(new[]
+            var settings = ParseArguments(new[]
             {
                 "-t",
 				"-vq",
@@ -496,11 +497,12 @@ namespace UploadFIG.Test
 				"-s", "https://build.fhir.org/ig/hl7au/au-fhir-core/package.tgz",
                 "-odf", outputFile,
             });
-            Assert.AreEqual(0, result);
+            var result = await Program.UploadPackageInternal(settings);
+            Assert.AreEqual(0, result.Value);
 
-			Assert.AreEqual(26, Program.successes);
-			Assert.AreEqual(0, Program.failures);
-			Assert.AreEqual(0, Program.validationErrors);
+			Assert.AreEqual(26, result.successes);
+			Assert.AreEqual(0, result.failures);
+			Assert.AreEqual(0, result.validationErrors);
 		}
 
 		[TestMethod]
@@ -508,7 +510,7 @@ namespace UploadFIG.Test
         {
             // "commandLineArgs": "-d https://localhost:44391 -pid hl7.fhir.au.base -fd -pdv false"
             string outputFile = "c:\\temp\\uploadfig-dump-aubase.json";
-            var result = await Program.Main(new[]
+            var settings = ParseArguments(new[]
             {
                 "-t",
 				"-vq",
@@ -519,11 +521,12 @@ namespace UploadFIG.Test
 				"-ets", "https://tx.dev.hl7.org.au/fhir",
                 "-odf", outputFile,
             });
-            Assert.AreEqual(0, result);
+            var result = await Program.UploadPackageInternal(settings);
+            Assert.AreEqual(0, result.Value);
 
-			Assert.AreEqual(138, Program.successes);
-			Assert.AreEqual(0, Program.failures);
-			Assert.AreEqual(0, Program.validationErrors);
+			Assert.AreEqual(138, result.successes);
+			Assert.AreEqual(0, result.failures);
+			Assert.AreEqual(0, result.validationErrors);
         }
 
         [TestMethod]
@@ -531,7 +534,7 @@ namespace UploadFIG.Test
         {
             // "commandLineArgs": "-d https://localhost:44391 -pid hl7.fhir.au.base -fd -pdv false"
             string outputFile = "c:\\temp\\uploadfig-dump-aubase.json";
-            var result = await Program.Main(new[]
+            var settings = ParseArguments(new[]
             {
                 "-t",
 				"-vq",
@@ -539,11 +542,12 @@ namespace UploadFIG.Test
 				"-pid", "hl7.fhir.au.base",
                 "-odf", outputFile,
             });
-            Assert.AreEqual(0, result);
+            var result = await Program.UploadPackageInternal(settings);
+            Assert.AreEqual(0, result.Value);
 
-			Assert.AreEqual(138, Program.successes);
-			Assert.AreEqual(0, Program.failures);
-			Assert.AreEqual(0, Program.validationErrors);
+			Assert.AreEqual(138, result.successes);
+			Assert.AreEqual(0, result.failures);
+			Assert.AreEqual(0, result.validationErrors);
         }
 
         [TestMethod]
@@ -551,7 +555,7 @@ namespace UploadFIG.Test
         {
             // "commandLineArgs": "-d https://localhost:44391 -pid hl7.fhir.us.sdoh-clinicalcare -fd -pdv false --verbose"
             string outputFile = "c:\\temp\\uploadfig-dump-sdoh-clinicalcare.json";
-            var result = await Program.Main(new[]
+            var settings = ParseArguments(new[]
             {
                 "-t",
 				"-vq",
@@ -560,11 +564,12 @@ namespace UploadFIG.Test
                 "-odf", outputFile,
                 // "--verbose",
             });
-            Assert.AreEqual(0, result);
+            var result = await Program.UploadPackageInternal(settings);
+            Assert.AreEqual(0, result.Value);
 
-			Assert.AreEqual(42, Program.successes);
-			Assert.AreEqual(0, Program.failures);
-			Assert.AreEqual(3, Program.validationErrors);
+			Assert.AreEqual(42, result.successes);
+			Assert.AreEqual(0, result.failures);
+			Assert.AreEqual(3, result.validationErrors);
 		}
 
 		[TestMethod]
@@ -572,7 +577,7 @@ namespace UploadFIG.Test
         {
             // "commandLineArgs": "-d https://localhost:44391 -pid hl7.fhir.us.sdoh-clinicalcare -fd -pdv false --verbose"
             string outputFile = "c:\\temp\\uploadfig-dump-sdoh-clinicalcare.json";
-            var result = await Program.Main(new[]
+            var settings = ParseArguments(new[]
             {
                 "-t",
 				"-vq",
@@ -582,11 +587,12 @@ namespace UploadFIG.Test
 				"-s", "C:\\git\\hl7\\fhir-sdoh-clinicalcare\\output/package.tgz",
 				"-odf", outputFile,
             });
-            Assert.AreEqual(0, result);
+            var result = await Program.UploadPackageInternal(settings);
+            Assert.AreEqual(0, result.Value);
 
-			Assert.AreEqual(42, Program.successes);
-			Assert.AreEqual(0, Program.failures);
-			Assert.AreEqual(1, Program.validationErrors);
+			Assert.AreEqual(42, result.successes);
+			Assert.AreEqual(0, result.failures);
+			Assert.AreEqual(1, result.validationErrors);
 		}
 
 
@@ -595,7 +601,7 @@ namespace UploadFIG.Test
         {
             // "commandLineArgs": "-d https://localhost:44391 -pid hl7.fhir.us.sdoh-clinicalcare -fd -pdv false --verbose"
             string outputFile = "c:\\temp\\uploadfig-dump-subs-backportCI.json";
-            var result = await Program.Main(new[]
+            var settings = ParseArguments(new[]
             {
                 "-t",
 				"-vq",
@@ -604,11 +610,12 @@ namespace UploadFIG.Test
                 "-s", "http://build.fhir.org/ig/HL7/fhir-subscription-backport-ig/package.tgz",
                 "-odf", outputFile,
             });
-            Assert.AreEqual(0, result);
+            var result = await Program.UploadPackageInternal(settings);
+            Assert.AreEqual(0, result.Value);
 
-			Assert.AreEqual(20, Program.successes);
-			Assert.AreEqual(0, Program.failures);
-			Assert.AreEqual(1, Program.validationErrors);
+			Assert.AreEqual(20, result.successes);
+			Assert.AreEqual(0, result.failures);
+			Assert.AreEqual(1, result.validationErrors);
 		}
 
 		[TestMethod]
@@ -616,7 +623,7 @@ namespace UploadFIG.Test
         {
             // "commandLineArgs": "-d https://localhost:44391 -pid hl7.fhir.us.sdoh-clinicalcare -fd -pdv false --verbose"
             string outputFile = "c:\\temp\\uploadfig-dump-ihe-mhd.json";
-            var result = await Program.Main(new[]
+            var settings = ParseArguments(new[]
             {
                 "-t",
 				"-vq",
@@ -626,17 +633,18 @@ namespace UploadFIG.Test
                 // "-fd", "false"
                 // "-sf", "package/StructureDefinition-IHE.MHD.EntryUUID.Identifier.json",
             });
-            Assert.AreEqual(0, result);
+            var result = await Program.UploadPackageInternal(settings);
+            Assert.AreEqual(0, result.Value);
 
-			Assert.AreEqual(49, Program.successes);
-			Assert.AreEqual(0, Program.failures);
-			Assert.AreEqual(2, Program.validationErrors);
+			Assert.AreEqual(49, result.successes);
+			Assert.AreEqual(0, result.failures);
+			Assert.AreEqual(2, result.validationErrors);
         }
 
 		[TestMethod]
 		public async Task CheckDavinciRA()
 		{
-			var result = await Program.Main(new[]
+			var settings = ParseArguments(new[]
 			{
 				"-t",
 				"-vq",
@@ -647,17 +655,18 @@ namespace UploadFIG.Test
 				"-of", @"c:\temp\UploadFIG-dump-DavinciRA-bundle.json",
 				"-pcv",
             });
-			Assert.AreEqual(0, result);
+            var result = await Program.UploadPackageInternal(settings);
+            Assert.AreEqual(0, result.Value);
 
-			Assert.AreEqual(55, Program.successes);
-			Assert.AreEqual(0, Program.failures);
-			Assert.AreEqual(0, Program.validationErrors);
+			Assert.AreEqual(55, result.successes);
+			Assert.AreEqual(0, result.failures);
+			Assert.AreEqual(0, result.validationErrors);
 		}
 
 		[TestMethod]
 		public async Task CheckDavinciCRD()
 		{
-			var result = await Program.Main(new[]
+			var settings = ParseArguments(new[]
 			{
 				"-t",
 				"-vq",
@@ -676,11 +685,12 @@ namespace UploadFIG.Test
                 // "-fd", "false"
 				"-of", @"c:\temp\uploadfig-dump-daviniCRD-bundle.json",
             });
-			Assert.AreEqual(0, result);
+            var result = await Program.UploadPackageInternal(settings);
+            Assert.AreEqual(0, result.Value);
 
-			Assert.AreEqual(226, Program.successes);
-			Assert.AreEqual(0, Program.failures);
-			Assert.AreEqual(0, Program.validationErrors);
+			Assert.AreEqual(226, result.successes);
+			Assert.AreEqual(0, result.failures);
+			Assert.AreEqual(0, result.validationErrors);
 		}
 	}
 }

--- a/UploadFIG.Test/TestWriter.cs
+++ b/UploadFIG.Test/TestWriter.cs
@@ -1,0 +1,35 @@
+﻿using System.Text;
+
+public class TestWriter : TextWriter
+{
+    //public ITestOutputHelper OutputWriter { get; }
+
+    public override Encoding Encoding => Encoding.ASCII;
+
+    //public TestWriter(ITestOutputHelper outputWriter)
+    //{
+    //    OutputWriter = outputWriter;
+    //}
+    private StringBuilder cache = new();
+    public override void Write(char value)
+    {
+        if (value == '\r')
+            return;
+        if (value == '\n')
+        {
+            // OutputWriter.WriteLine(cache.ToString());
+            cache.Clear();
+        }
+        else
+        {
+            cache.Append(value);
+        }
+    }
+    public override void Flush()
+    {
+        if (cache.Length == 0)
+            return;
+        // OutputWriter.WriteLine(cache.ToString());
+        cache.Clear();
+    }
+}

--- a/UploadFIG/CanonicalDetails.cs
+++ b/UploadFIG/CanonicalDetails.cs
@@ -3,9 +3,9 @@ using Hl7.Fhir.Model;
 
 namespace UploadFIG
 {
-	[System.Diagnostics.DebuggerDisplay(@"Canonical: {canonical}|{version}")] // http://blogs.msdn.com/b/jaredpar/archive/2011/03/18/debuggerdisplay-attribute-best-practices.aspx
-	public class CanonicalDetails : IComparable<CanonicalDetails>
-	{
+    [System.Diagnostics.DebuggerDisplay(@"Canonical: {canonical}|{version}")] // http://blogs.msdn.com/b/jaredpar/archive/2011/03/18/debuggerdisplay-attribute-best-practices.aspx
+    public class CanonicalDetails : IComparable<CanonicalDetails>
+    {
         public CanonicalDetails() { }
 
         [JsonPropertyName("resourceType")]
@@ -27,14 +27,14 @@ namespace UploadFIG
 
         public List<Resource> requiredBy { get; } = new List<Resource>();
 
-		int IComparable<CanonicalDetails>.CompareTo(CanonicalDetails other)
-		{
-			if (other == null)
-				return -1;
-			int result = string.CompareOrdinal(Canonical, other.Canonical);
-			if (result == 0)
-				result = string.CompareOrdinal(Version, other.Version);
-			return result;
-		}
-	}
+        int IComparable<CanonicalDetails>.CompareTo(CanonicalDetails other)
+        {
+            if (other == null)
+                return -1;
+            int result = string.CompareOrdinal(Canonical, other.Canonical);
+            if (result == 0)
+                result = string.CompareOrdinal(Version, other.Version);
+            return result;
+        }
+    }
 }

--- a/UploadFIG/CanonicalDetailsComparer.cs
+++ b/UploadFIG/CanonicalDetailsComparer.cs
@@ -1,0 +1,17 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace UploadFIG
+{
+    public class CanonicalDetailsComparer : IEqualityComparer<CanonicalDetails>
+    {
+        public bool Equals(CanonicalDetails x, CanonicalDetails y)
+        {
+            return (x as IComparable<CanonicalDetails>).CompareTo(y) == 0;
+        }
+
+        public int GetHashCode([DisallowNull] CanonicalDetails obj)
+        {
+            return $"{obj.Canonical}|{obj.Version}".GetHashCode();
+        }
+    }
+}

--- a/UploadFIG/DependencyChecker.cs
+++ b/UploadFIG/DependencyChecker.cs
@@ -1040,7 +1040,7 @@ namespace UploadFIG
 				yield return detail;
 		}
 
-		public async Task<List<Resource>> ReadResourcesFromPackage(PackageDetails pd, Func<string, bool> SkipFile, Stream sourceStream, Common_Processor versionAgnosticProcessor, List<string> errs, List<string> errFiles, bool verbose, List<string> resourceTypeNames)
+		public async Task<List<Resource>> ReadResourcesFromPackage(PackageDetails pd, Func<string, bool> SkipFile, Stream sourceStream, Common_Processor versionAgnosticProcessor, List<string> errs, List<string> errFiles, bool verbose, List<string> resourceTypeNames, Program.Result result)
 		{
 			// skip back to the start (for cases where the package.json isn't the first resource)
 			sourceStream.Seek(0, SeekOrigin.Begin);
@@ -1082,7 +1082,7 @@ namespace UploadFIG
 						catch (Exception ex)
 						{
 							Console.Error.WriteLine($"ERROR: ({exampleName}) {ex.Message}");
-							System.Threading.Interlocked.Increment(ref Program.failures);
+							System.Threading.Interlocked.Increment(ref result.failures);
 							if (!errs.Contains(ex.Message))
 								errs.Add(ex.Message);
 							errFiles.Add(exampleName);

--- a/UploadFIG/DependencyChecker.cs
+++ b/UploadFIG/DependencyChecker.cs
@@ -827,7 +827,8 @@ namespace UploadFIG
 						ConsoleEx.Write(ConsoleColor.Yellow, ResourcePackageSource.PackageSourceVersion(useResource));
 						Console.WriteLine($" from {String.Join(", ", distinctVersionSources)}");
 					}
-					canonical.resource = useResource as Resource;
+                    useResource.MarkUsedBy(canonical);
+                    canonical.resource = useResource.resource as Resource;
 				}
 			}
 
@@ -1027,7 +1028,7 @@ namespace UploadFIG
 		/// <param name="versionAgnosticProcessor"></param>
 		/// <param name="errFiles"></param>
 		/// <returns></returns>
-		internal IEnumerable<IVersionableConformanceResource> ResolveCanonical(PackageDetails pd, CanonicalDetails canonicalUrl, Common_Processor versionAgnosticProcessor, List<String> errFiles)
+		internal IEnumerable<FileDetail> ResolveCanonical(PackageDetails pd, CanonicalDetails canonicalUrl, Common_Processor versionAgnosticProcessor, List<String> errFiles)
 		{
 			// Is this in any of the dependencies?
 			foreach (var dep in pd.dependencies)
@@ -1109,7 +1110,7 @@ namespace UploadFIG
 			}
 
 			if (detail.resource is IVersionableConformanceResource ivr)
-				yield return ivr;
+				yield return detail;
 		}
 
 		public async Task<List<Resource>> ReadResourcesFromPackage(PackageDetails pd, Func<string, bool> SkipFile, Stream sourceStream, Common_Processor versionAgnosticProcessor, List<string> errs, List<string> errFiles, bool verbose, List<string> resourceTypeNames)
@@ -1197,6 +1198,7 @@ namespace UploadFIG
 							}
 							pd.Files.Add(indexDetails);
 						}
+                        indexDetails.UsedBy.Add("(root package)");
 						indexDetails.resource = resource;
 					}
 				}

--- a/UploadFIG/DependencyChecker.cs
+++ b/UploadFIG/DependencyChecker.cs
@@ -904,7 +904,7 @@ namespace UploadFIG
 						if (_settings.Verbose)
 							Console.WriteLine($"    Detected {f.url}|{f.version} in {pd.packageId}|{pd.packageVersion}");
 
-						if (f.hasDuplicateDefinitions)
+						if (f.hasDuplicateDefinitions && f.resource == null)
 							Console.WriteLine($"    Detected multiple versions of {f.url}|{f.version} in {pd.packageId}|{pd.packageVersion} ({String.Join(", ", files.Where(f2 => f2.url == f.url ).Select(f2 => f2.filename))})");
 						try
 						{

--- a/UploadFIG/DependencyChecker.cs
+++ b/UploadFIG/DependencyChecker.cs
@@ -24,6 +24,8 @@ namespace UploadFIG
 		ModelInspector _inspector;
 		FHIRVersion _fhirVersion;
 		TempPackageCache _packageCache;
+        Common_Processor _versionAgnosticProcessor;
+        List<String> _errFiles;
 
 		/// <summary>
 		/// Cache of loaded resource instances, indexed by packageId|packageVersion|filename
@@ -31,12 +33,14 @@ namespace UploadFIG
 		/// </summary>
 		Dictionary<string, Resource> _cacheResources = new Dictionary<string, Resource>();
 
-		public DependencyChecker(Settings settings, FHIRVersion fhirVersion, ModelInspector inspector, TempPackageCache packageCache)
+		public DependencyChecker(Settings settings, FHIRVersion fhirVersion, ModelInspector inspector, TempPackageCache packageCache, Common_Processor versionAgnosticProcessor, List<String> errFiles)
 		{
 			_settings = settings;
 			_inspector = inspector;
 			_fhirVersion = fhirVersion;
 			_packageCache = packageCache;
+            _versionAgnosticProcessor = versionAgnosticProcessor;
+            _errFiles = errFiles;
 		}
 
 		public static void VerifyDependenciesOnServer(Settings settings, BaseFhirClient clientFhir, List<CanonicalDetails> requiresCanonicals)
@@ -104,14 +108,14 @@ namespace UploadFIG
 		/// </summary>
 		/// <param name="resourcesToProcess"></param>
 		/// <returns></returns>
-		public IEnumerable<CanonicalDetails> ScanForCanonicals(IEnumerable<Resource> resourcesToProcess)
+		public IEnumerable<CanonicalDetails> ScanForCanonicals(PackageDetails pd, IEnumerable<Resource> resourcesToProcess)
         {
-            return ScanForCanonicals(new List<CanonicalDetails>(), resourcesToProcess);
+            return ScanForCanonicals(pd, new List<CanonicalDetails>(), resourcesToProcess);
         }
 
 		public void ScanForCanonicals(PackageDetails pd)
 		{
-			var requiresDirectCanonicals = ScanForCanonicals(pd.resources).ToList();
+			var requiresDirectCanonicals = ScanForCanonicals(pd, pd.resources).ToList();
 			var externalCanonicals = FilterOutCanonicals(requiresDirectCanonicals, pd.resources).ToList();
 			pd.RequiresCanonicals = externalCanonicals;
 		}
@@ -122,7 +126,7 @@ namespace UploadFIG
 		/// <param name="initialCanonicals"></param>
 		/// <param name="resourcesToProcess"></param>
 		/// <returns></returns>
-		public IEnumerable<CanonicalDetails> ScanForCanonicals(IEnumerable<CanonicalDetails> initialCanonicals, IEnumerable<Resource> resourcesToProcess)
+		public IEnumerable<CanonicalDetails> ScanForCanonicals(PackageDetails pd, IEnumerable<CanonicalDetails> initialCanonicals, IEnumerable<Resource> resourcesToProcess)
         {
             // Review this against https://hl7.org/fhir/uv/crmi/2024Jan/distribution.html#dependency-tracing
             List<CanonicalDetails> requiresCanonicals = new List<CanonicalDetails>(initialCanonicals);
@@ -130,49 +134,49 @@ namespace UploadFIG
             // Scan for any extensions used (to read their canonical URL)
             foreach (var resource in resourcesToProcess)
             {
-                ScanForExtensions(requiresCanonicals, resource, resource);
+                ScanForExtensions(pd, requiresCanonicals, resource, resource);
             }
 
             // Scan for resource specific canonicals
             foreach (var resource in resourcesToProcess.OfType<StructureDefinition>())
             {
-                ScanForCanonicals(requiresCanonicals, resource);
+                ScanForCanonicals(pd, requiresCanonicals, resource);
             }
 
             foreach (var resource in resourcesToProcess.OfType<ValueSet>())
             {
-                ScanForCanonicals(requiresCanonicals, resource);
+                ScanForCanonicals(pd, requiresCanonicals, resource);
             }
 
             foreach (var resource in resourcesToProcess.OfType<CodeSystem>())
             {
-                ScanForCanonicals(requiresCanonicals, resource);
+                ScanForCanonicals(pd, requiresCanonicals, resource);
             }
 
             foreach (var resource in resourcesToProcess.OfType<r4.Hl7.Fhir.Model.ConceptMap>())
             {
-                ScanForCanonicalsR4(requiresCanonicals, resource);
+                ScanForCanonicalsR4(pd, requiresCanonicals, resource);
             }
             foreach (var resource in resourcesToProcess.OfType<r4b.Hl7.Fhir.Model.ConceptMap>())
             {
-                ScanForCanonicals(requiresCanonicals, resource);
+                ScanForCanonicals(pd, requiresCanonicals, resource);
             }
             foreach (var resource in resourcesToProcess.OfType<r5.Hl7.Fhir.Model.ConceptMap>())
             {
-                ScanForCanonicalsR5(requiresCanonicals, resource);
+                ScanForCanonicalsR5(pd, requiresCanonicals, resource);
             }
 
             foreach (var resource in resourcesToProcess.OfType<r4.Hl7.Fhir.Model.Questionnaire>())
             {
-                ScanForCanonicalsR4(requiresCanonicals, resource);
+                ScanForCanonicalsR4(pd, requiresCanonicals, resource);
             }
             foreach (var resource in resourcesToProcess.OfType<r4b.Hl7.Fhir.Model.Questionnaire>())
             {
-                ScanForCanonicals(requiresCanonicals, resource);
+                ScanForCanonicals(pd, requiresCanonicals, resource);
             }
             foreach (var resource in resourcesToProcess.OfType<r5.Hl7.Fhir.Model.Questionnaire>())
             {
-                ScanForCanonicalsR5(requiresCanonicals, resource);
+                ScanForCanonicalsR5(pd, requiresCanonicals, resource);
             }
 
 			// StructureMaps
@@ -219,7 +223,7 @@ namespace UploadFIG
 						if (requiresCanonicals.Any(c => c.Canonical == canonical.Value))
 							continue;
 						if (!IsCoreOrExtensionOrToolsCanonical(canonical.Value))
-							CheckRequiresCanonical(resource, "unknown", canonical.Value, requiresCanonicals, (newValue) => canonical.Value = newValue);
+							CheckRequiresCanonical(pd, resource, "unknown", canonical.Value, requiresCanonicals, (newValue) => canonical.Value = newValue);
 					}
 				}
 			}
@@ -227,23 +231,23 @@ namespace UploadFIG
 			return requiresCanonicals.Where(r => !initialCanonicals.Any(ic => ic.Canonical == r.Canonical));
         }
 
-		private void ScanForExtensions(List<CanonicalDetails> requiresCanonicals, Resource resource, Base prop)
+		private void ScanForExtensions(PackageDetails pd, List<CanonicalDetails> requiresCanonicals, Resource resource, Base prop)
         {
             foreach (var child in prop.Children)
             {
                 if (child is Extension extension)
                 {
-                    CheckRequiresCanonical(resource, "StructureDefinition", extension.Url, requiresCanonicals, (value) => extension.Url = value);
+                    CheckRequiresCanonical(pd, resource, "StructureDefinition", extension.Url, requiresCanonicals, (value) => extension.Url = value);
                     if (extension.Value != null)
                     {
                         // This will scan for extensions on extension values (not complex extensions)
-                        ScanForExtensions(requiresCanonicals, resource, extension.Value);
+                        ScanForExtensions(pd, requiresCanonicals, resource, extension.Value);
                     }
                 }
                 else
                 {
                     // We don't scan extensions (which would find complex extensions
-                    ScanForExtensions(requiresCanonicals, resource, child);
+                    ScanForExtensions(pd, requiresCanonicals, resource, child);
                 }
             }
         }
@@ -424,7 +428,7 @@ namespace UploadFIG
 			"vsacOpModifier",
 		});
 
-        private void CheckRequiresCanonical(Resource resource, string canonicalType, string canonicalUrl, List<CanonicalDetails> requiresCanonicals, Action<string> patchVersionedCanonical = null)
+        private void CheckRequiresCanonical(PackageDetails pd, Resource resource, string canonicalType, string canonicalUrl, List<CanonicalDetails> requiresCanonicals, Action<string> patchVersionedCanonical = null)
         {
 			if (!string.IsNullOrEmpty(canonicalUrl))
             {
@@ -476,15 +480,15 @@ namespace UploadFIG
             }
         }
 
-        private void ScanForCanonicalsR4(List<CanonicalDetails> requiresCanonicals, r4.Hl7.Fhir.Model.ConceptMap resource)
+        private void ScanForCanonicalsR4(PackageDetails pd, List<CanonicalDetails> requiresCanonicals, r4.Hl7.Fhir.Model.ConceptMap resource)
         {
-            CheckRequiresCanonical(resource, "ValueSet", resource.Source as Canonical, requiresCanonicals, (value) => (resource.Source as Canonical).Value = value);
-            CheckRequiresCanonical(resource, "ValueSet", resource.Target as Canonical, requiresCanonicals, (value) => (resource.Target as Canonical).Value = value);
+            CheckRequiresCanonical(pd, resource, "ValueSet", resource.Source as Canonical, requiresCanonicals, (value) => (resource.Source as Canonical).Value = value);
+            CheckRequiresCanonical(pd, resource, "ValueSet", resource.Target as Canonical, requiresCanonicals, (value) => (resource.Target as Canonical).Value = value);
 
             foreach (var group in resource.Group)
             {
-                CheckRequiresCanonical(resource, "CodeSystem", group.Source, requiresCanonicals, (value) => { group.Source = value; });
-                CheckRequiresCanonical(resource, "CodeSystem", group.Target, requiresCanonicals, (value) => { group.Target = value; });
+                CheckRequiresCanonical(pd, resource, "CodeSystem", group.Source, requiresCanonicals, (value) => { group.Source = value; });
+                CheckRequiresCanonical(pd, resource, "CodeSystem", group.Target, requiresCanonicals, (value) => { group.Target = value; });
 
                 foreach (var element in group.Element)
                 {
@@ -492,30 +496,30 @@ namespace UploadFIG
                     {
                         foreach (var dependsOn in target.DependsOn)
                         {
-                            CheckRequiresCanonical(resource, "CodeSystem", dependsOn.System, requiresCanonicals, (value) => { dependsOn.System = value; });
+                            CheckRequiresCanonical(pd, resource, "CodeSystem", dependsOn.System, requiresCanonicals, (value) => { dependsOn.System = value; });
                         }
                         foreach (var product in target.Product)
                         {
-                            CheckRequiresCanonical(resource, "CodeSystem", product.System, requiresCanonicals, (value) => { product.System = value; });
+                            CheckRequiresCanonical(pd, resource, "CodeSystem", product.System, requiresCanonicals, (value) => { product.System = value; });
                         }
                     }
                 }
                 if (group.Unmapped?.Url != null)
                 {
-                    CheckRequiresCanonical(resource, "ConceptMap", group.Unmapped.Url, requiresCanonicals, (value) => { group.Unmapped.Url = value; });
+                    CheckRequiresCanonical(pd, resource, "ConceptMap", group.Unmapped.Url, requiresCanonicals, (value) => { group.Unmapped.Url = value; });
                 }
             }
         }
 
-        private void ScanForCanonicals(List<CanonicalDetails> requiresCanonicals, r4b.Hl7.Fhir.Model.ConceptMap resource)
+        private void ScanForCanonicals(PackageDetails pd, List<CanonicalDetails> requiresCanonicals, r4b.Hl7.Fhir.Model.ConceptMap resource)
         {
-            CheckRequiresCanonical(resource, "ValueSet", resource.Source as Canonical, requiresCanonicals, (value) => (resource.Source as Canonical).Value = value);
-            CheckRequiresCanonical(resource, "ValueSet", resource.Target as Canonical, requiresCanonicals, (value) => (resource.Target as Canonical).Value = value);
+            CheckRequiresCanonical(pd, resource, "ValueSet", resource.Source as Canonical, requiresCanonicals, (value) => (resource.Source as Canonical).Value = value);
+            CheckRequiresCanonical(pd, resource, "ValueSet", resource.Target as Canonical, requiresCanonicals, (value) => (resource.Target as Canonical).Value = value);
 
             foreach (var group in resource.Group)
             {
-                CheckRequiresCanonical(resource, "CodeSystem", group.Source, requiresCanonicals, (value) => { group.Source = value; });
-                CheckRequiresCanonical(resource, "CodeSystem", group.Target, requiresCanonicals, (value) => { group.Target = value; });
+                CheckRequiresCanonical(pd, resource, "CodeSystem", group.Source, requiresCanonicals, (value) => { group.Source = value; });
+                CheckRequiresCanonical(pd, resource, "CodeSystem", group.Target, requiresCanonicals, (value) => { group.Target = value; });
 
                 foreach (var element in group.Element)
                 {
@@ -523,64 +527,64 @@ namespace UploadFIG
                     {
                         foreach (var dependsOn in target.DependsOn)
                         {
-                            CheckRequiresCanonical(resource, "CodeSystem", dependsOn.System, requiresCanonicals, (value) => { dependsOn.System = value; });
+                            CheckRequiresCanonical(pd, resource, "CodeSystem", dependsOn.System, requiresCanonicals, (value) => { dependsOn.System = value; });
                         }
                         foreach (var product in target.Product)
                         {
-                            CheckRequiresCanonical(resource, "CodeSystem", product.System, requiresCanonicals, (value) => { product.System = value; });
+                            CheckRequiresCanonical(pd, resource, "CodeSystem", product.System, requiresCanonicals, (value) => { product.System = value; });
                         }
                     }
                 }
                 if (group.Unmapped != null)
                 {
-                    CheckRequiresCanonical(resource, "ConceptMap", group.Unmapped.Url, requiresCanonicals, (value) => { group.Unmapped.Url = value; });
+                    CheckRequiresCanonical(pd, resource, "ConceptMap", group.Unmapped.Url, requiresCanonicals, (value) => { group.Unmapped.Url = value; });
                 }
             }
         }
 
-        private void ScanForCanonicalsR5(List<CanonicalDetails> requiresCanonicals, r5.Hl7.Fhir.Model.ConceptMap resource)
+        private void ScanForCanonicalsR5(PackageDetails pd, List<CanonicalDetails> requiresCanonicals, r5.Hl7.Fhir.Model.ConceptMap resource)
         {
             foreach (var prop in resource.Property)
             {
-                CheckRequiresCanonical(resource, "CodeSystem", prop.System, requiresCanonicals, (value) => { prop.System = value; });
+                CheckRequiresCanonical(pd, resource, "CodeSystem", prop.System, requiresCanonicals, (value) => { prop.System = value; });
             }
-            CheckRequiresCanonical(resource, "ValueSet", resource.SourceScope as Canonical ?? (resource.SourceScope as FhirUri)?.Value, requiresCanonicals);
-            CheckRequiresCanonical(resource, "ValueSet", resource.TargetScope as Canonical ?? (resource.TargetScope as FhirUri)?.Value, requiresCanonicals);
+            CheckRequiresCanonical(pd, resource, "ValueSet", resource.SourceScope as Canonical ?? (resource.SourceScope as FhirUri)?.Value, requiresCanonicals);
+            CheckRequiresCanonical(pd, resource, "ValueSet", resource.TargetScope as Canonical ?? (resource.TargetScope as FhirUri)?.Value, requiresCanonicals);
 
             foreach (var group in resource.Group)
             {
-                CheckRequiresCanonical(resource, "CodeSystem", group.Source, requiresCanonicals, (value) => { group.Source = value; });
-                CheckRequiresCanonical(resource, "CodeSystem", group.Target, requiresCanonicals, (value) => { group.Target = value; });
+                CheckRequiresCanonical(pd, resource, "CodeSystem", group.Source, requiresCanonicals, (value) => { group.Source = value; });
+                CheckRequiresCanonical(pd, resource, "CodeSystem", group.Target, requiresCanonicals, (value) => { group.Target = value; });
 
                 foreach (var element in group.Element)
                 {
-                    CheckRequiresCanonical(resource, "ValueSet", element.ValueSet, requiresCanonicals, (value) => { element.ValueSet = value; });
+                    CheckRequiresCanonical(pd, resource, "ValueSet", element.ValueSet, requiresCanonicals, (value) => { element.ValueSet = value; });
 
                     foreach (var target in element.Target)
                     {
-                        CheckRequiresCanonical(resource, "ValueSet", target.ValueSet, requiresCanonicals, (value) => { target.ValueSet = value; });
+                        CheckRequiresCanonical(pd, resource, "ValueSet", target.ValueSet, requiresCanonicals, (value) => { target.ValueSet = value; });
                         foreach (var dependsOn in target.DependsOn)
                         {
-                            CheckRequiresCanonical(resource, "ValueSet", dependsOn.ValueSet, requiresCanonicals, (value) => { dependsOn.ValueSet = value; });
+                            CheckRequiresCanonical(pd, resource, "ValueSet", dependsOn.ValueSet, requiresCanonicals, (value) => { dependsOn.ValueSet = value; });
                         }
                         foreach (var product in target.Product)
                         {
-                            CheckRequiresCanonical(resource, "ValueSet", product.ValueSet, requiresCanonicals, (value) => { product.ValueSet = value; });
+                            CheckRequiresCanonical(pd, resource, "ValueSet", product.ValueSet, requiresCanonicals, (value) => { product.ValueSet = value; });
                         }
                     }
                 }
                 if (group.Unmapped != null)
                 {
-                    CheckRequiresCanonical(resource, "ValueSet", group.Unmapped.ValueSet, requiresCanonicals, (value) => { group.Unmapped.ValueSet = value; });
-                    CheckRequiresCanonical(resource, "ConceptMap", group.Unmapped.OtherMap, requiresCanonicals, (value) => { group.Unmapped.OtherMap = value; });
+                    CheckRequiresCanonical(pd, resource, "ValueSet", group.Unmapped.ValueSet, requiresCanonicals, (value) => { group.Unmapped.ValueSet = value; });
+                    CheckRequiresCanonical(pd, resource, "ConceptMap", group.Unmapped.OtherMap, requiresCanonicals, (value) => { group.Unmapped.OtherMap = value; });
                 }
             }
         }
 
 
-        private void ScanForCanonicals(List<CanonicalDetails> requiresCanonicals, CodeSystem resource)
+        private void ScanForCanonicals(PackageDetails pd, List<CanonicalDetails> requiresCanonicals, CodeSystem resource)
         {
-            CheckRequiresCanonical(resource, "CodeSystem", resource.Supplements, requiresCanonicals, (value) => { resource.Supplements = value; });
+            CheckRequiresCanonical(pd, resource, "CodeSystem", resource.Supplements, requiresCanonicals, (value) => { resource.Supplements = value; });
             // Removing this check for the "complete valueset" reference as this is quite often not there
             // and if others need it, they would have a reference to it.
             // CheckRequiresCanonical(resource, "ValueSet", resource.ValueSet, requiresCanonicals);
@@ -592,16 +596,16 @@ namespace UploadFIG
             }
         }
 
-        private void ScanForCanonicals(List<CanonicalDetails> requiresCanonicals, ValueSet resource)
+        private void ScanForCanonicals(PackageDetails pd, List<CanonicalDetails> requiresCanonicals, ValueSet resource)
         {
             if (resource?.Compose?.Include != null)
             {
                 foreach (var include in resource?.Compose?.Include)
                 {
-                    CheckRequiresCanonical(resource, "CodeSystem", include.System, requiresCanonicals, (value) => { include.System = value; });
+                    CheckRequiresCanonical(pd, resource, "CodeSystem", include.System, requiresCanonicals, (value) => { include.System = value; });
                     foreach (var binding in include.ValueSet)
                     {
-                        CheckRequiresCanonical(resource, "ValueSet", binding, requiresCanonicals);
+                        CheckRequiresCanonical(pd, resource, "ValueSet", binding, requiresCanonicals);
                     }
                 }
             }
@@ -609,20 +613,20 @@ namespace UploadFIG
             {
                 foreach (var exclude in resource?.Compose?.Exclude)
                 {
-                    CheckRequiresCanonical(resource, "CodeSystem", exclude.System, requiresCanonicals, (value) => { exclude.System = value; });
+                    CheckRequiresCanonical(pd, resource, "CodeSystem", exclude.System, requiresCanonicals, (value) => { exclude.System = value; });
                     foreach (var binding in exclude.ValueSet)
                     {
-                        CheckRequiresCanonical(resource, "ValueSet", binding, requiresCanonicals);
+                        CheckRequiresCanonical(pd, resource, "ValueSet", binding, requiresCanonicals);
                     }
                 }
             }
         }
 
-        private void ScanForCanonicals(List<CanonicalDetails> requiresCanonicals, StructureDefinition resource)
+        private void ScanForCanonicals(PackageDetails pd, List<CanonicalDetails> requiresCanonicals, StructureDefinition resource)
         {
-            CheckRequiresCanonical(resource, "StructureDefinition", resource.BaseDefinition, requiresCanonicals, (value) => { resource.BaseDefinition = value; });
+            CheckRequiresCanonical(pd, resource, "StructureDefinition", resource.BaseDefinition, requiresCanonicals, (value) => { resource.BaseDefinition = value; });
             var compliesWithProfile = resource.GetExtensionValue<Canonical>("http://hl7.org/fhir/StructureDefinition/structuredefinition-compliesWithProfile");
-            CheckRequiresCanonical(resource, "StructureDefinition", compliesWithProfile?.Value, requiresCanonicals, (value) => { compliesWithProfile.Value = value; });
+            CheckRequiresCanonical(pd, resource, "StructureDefinition", compliesWithProfile?.Value, requiresCanonicals, (value) => { compliesWithProfile.Value = value; });
 
             if (resource?.Differential?.Element == null)
             {
@@ -642,21 +646,21 @@ namespace UploadFIG
                     // CheckRequiresCanonical(resource, "StructureDefinition", t.Code, requiresCanonicals);
                     foreach (var binding in t.Profile)
                     {
-                        CheckRequiresCanonical(resource, "StructureDefinition", binding, requiresCanonicals);
+                        CheckRequiresCanonical(pd, resource, "StructureDefinition", binding, requiresCanonicals);
                     }
                     foreach (var binding in t.TargetProfile)
                     {
-                        CheckRequiresCanonical(resource, "StructureDefinition", binding, requiresCanonicals);
+                        CheckRequiresCanonical(pd, resource, "StructureDefinition", binding, requiresCanonicals);
                     }
                 }
 
                 // Terminology Bindings
-                CheckRequiresCanonical(resource, "ValueSet", ed.Binding?.ValueSet, requiresCanonicals);
+                CheckRequiresCanonical(pd, resource, "ValueSet", ed.Binding?.ValueSet, requiresCanonicals);
                 if (ed.Binding?.Additional != null) // R5 prop name, r4 uses extensions
                 {
                     foreach (var binding in ed.Binding?.Additional?.Select(a => a.ValueSet))
                     {
-                        CheckRequiresCanonical(resource, "ValueSet", binding, requiresCanonicals);
+                        CheckRequiresCanonical(pd, resource, "ValueSet", binding, requiresCanonicals);
                     }
                 }
 				var additionalBindings = ed.Binding?.GetExtensions("http://hl7.org/fhir/tools/StructureDefinition/additional-binding");
@@ -665,126 +669,126 @@ namespace UploadFIG
 					foreach (var binding in additionalBindings)
 					{
 						var valueSet = binding.GetExtensionValue<Canonical>("valueSet");
-						CheckRequiresCanonical(resource, "ValueSet", valueSet, requiresCanonicals, (value) => valueSet.Value = value);
+						CheckRequiresCanonical(pd, resource, "ValueSet", valueSet, requiresCanonicals, (value) => valueSet.Value = value);
 					}
 				}
 
 				// value Alternatives
 				foreach (var alternateExtension in ed.ValueAlternatives)
                 {
-                    CheckRequiresCanonical(resource, "StructureDefinition", alternateExtension, requiresCanonicals);
+                    CheckRequiresCanonical(pd, resource, "StructureDefinition", alternateExtension, requiresCanonicals);
                 }
             }
         }
 
 
-        private void ScanForCanonicalsR4(List<CanonicalDetails> requiresCanonicals, r4.Hl7.Fhir.Model.Questionnaire resource)
+        private void ScanForCanonicalsR4(PackageDetails pd, List<CanonicalDetails> requiresCanonicals, r4.Hl7.Fhir.Model.Questionnaire resource)
         {
-            ScanForCanonicalsMetaProfiles(requiresCanonicals, resource);
+            ScanForCanonicalsMetaProfiles(pd, requiresCanonicals, resource);
 
             foreach (var derivedFrom in resource.DerivedFrom)
-                CheckRequiresCanonical(resource, "Questionnaire", derivedFrom, requiresCanonicals);
+                CheckRequiresCanonical(pd, resource, "Questionnaire", derivedFrom, requiresCanonicals);
 
-            ScanForSDCExtensionCanonicals(requiresCanonicals, resource);
+            ScanForSDCExtensionCanonicals(pd, requiresCanonicals, resource);
 
-            ScanForCanonicalsR4(requiresCanonicals, resource, resource.Item);
+            ScanForCanonicalsR4(pd, requiresCanonicals, resource, resource.Item);
         }
 
-        private void ScanForCanonicalsMetaProfiles(List<CanonicalDetails> requiresCanonicals, Resource resource)
+        private void ScanForCanonicalsMetaProfiles(PackageDetails pd, List<CanonicalDetails> requiresCanonicals, Resource resource)
         {
             if (resource.Meta != null)
             {
                 foreach (var profile in resource.Meta?.Profile)
                 {
-                    CheckRequiresCanonical(resource, "StructureDefinition", profile, requiresCanonicals);
+                    CheckRequiresCanonical(pd, resource, "StructureDefinition", profile, requiresCanonicals);
                 }
             }
         }
 
-        private void ScanForCanonicalsR4(List<CanonicalDetails> requiresCanonicals, Resource resource, List<r4.Hl7.Fhir.Model.Questionnaire.ItemComponent> items)
+        private void ScanForCanonicalsR4(PackageDetails pd, List<CanonicalDetails> requiresCanonicals, Resource resource, List<r4.Hl7.Fhir.Model.Questionnaire.ItemComponent> items)
         {
             if (items == null)
                 return;
             foreach (var item in items)
             {
-                CheckRequiresCanonical(resource, "ValueSet", item.AnswerValueSet, requiresCanonicals, (value) => { item.AnswerValueSet = value; });
-                CheckRequiresCanonical(resource, "StructureDefinition", item.Definition, requiresCanonicals, (value) => { item.Definition = value; });
+                CheckRequiresCanonical(pd, resource, "ValueSet", item.AnswerValueSet, requiresCanonicals, (value) => { item.AnswerValueSet = value; });
+                CheckRequiresCanonical(pd, resource, "StructureDefinition", item.Definition, requiresCanonicals, (value) => { item.Definition = value; });
 
-                ScanForSDCItemExtensionCanonicals(requiresCanonicals, resource, item);
-                ScanForCanonicalsR4(requiresCanonicals, resource, item.Item);
+                ScanForSDCItemExtensionCanonicals(pd, requiresCanonicals, resource, item);
+                ScanForCanonicalsR4(pd, requiresCanonicals, resource, item.Item);
             }
         }
 
-        private void ScanForCanonicals(List<CanonicalDetails> requiresCanonicals, r4b.Hl7.Fhir.Model.Questionnaire resource)
+        private void ScanForCanonicals(PackageDetails pd, List<CanonicalDetails> requiresCanonicals, r4b.Hl7.Fhir.Model.Questionnaire resource)
         {
-            ScanForCanonicalsMetaProfiles(requiresCanonicals, resource);
+            ScanForCanonicalsMetaProfiles(pd, requiresCanonicals, resource);
 
             foreach (var derivedFrom in resource.DerivedFrom)
-                CheckRequiresCanonical(resource, "Questionnaire", derivedFrom, requiresCanonicals);
+                CheckRequiresCanonical(pd, resource, "Questionnaire", derivedFrom, requiresCanonicals);
 
-            ScanForSDCExtensionCanonicals(requiresCanonicals, resource);
+            ScanForSDCExtensionCanonicals(pd, requiresCanonicals, resource);
 
-            ScanForCanonicals(requiresCanonicals, resource, resource.Item);
+            ScanForCanonicals(pd, requiresCanonicals, resource, resource.Item);
         }
 
-        private void ScanForCanonicals(List<CanonicalDetails> requiresCanonicals, Resource resource, List<r4b.Hl7.Fhir.Model.Questionnaire.ItemComponent> items)
+        private void ScanForCanonicals(PackageDetails pd, List<CanonicalDetails> requiresCanonicals, Resource resource, List<r4b.Hl7.Fhir.Model.Questionnaire.ItemComponent> items)
         {
             if (items == null)
                 return;
             foreach (var item in items)
             {
-                CheckRequiresCanonical(resource, "ValueSet", item.AnswerValueSet, requiresCanonicals, (value) => { item.AnswerValueSet = value; });
-                CheckRequiresCanonical(resource, "StructureDefinition", item.Definition, requiresCanonicals, (value) => { item.Definition = value; });
+                CheckRequiresCanonical(pd, resource, "ValueSet", item.AnswerValueSet, requiresCanonicals, (value) => { item.AnswerValueSet = value; });
+                CheckRequiresCanonical(pd, resource, "StructureDefinition", item.Definition, requiresCanonicals, (value) => { item.Definition = value; });
 
-                ScanForSDCItemExtensionCanonicals(requiresCanonicals, resource, item);
-                ScanForCanonicals(requiresCanonicals, resource, item.Item);
+                ScanForSDCItemExtensionCanonicals(pd, requiresCanonicals, resource, item);
+                ScanForCanonicals(pd, requiresCanonicals, resource, item.Item);
             }
         }
 
-        private void ScanForCanonicalsR5(List<CanonicalDetails> requiresCanonicals, r5.Hl7.Fhir.Model.Questionnaire resource)
+        private void ScanForCanonicalsR5(PackageDetails pd, List<CanonicalDetails> requiresCanonicals, r5.Hl7.Fhir.Model.Questionnaire resource)
         {
-            ScanForCanonicalsMetaProfiles(requiresCanonicals, resource);
+            ScanForCanonicalsMetaProfiles(pd, requiresCanonicals, resource);
 
             foreach (var derivedFrom in resource.DerivedFrom)
-                CheckRequiresCanonical(resource, "Questionnaire", derivedFrom, requiresCanonicals);
+                CheckRequiresCanonical(pd, resource, "Questionnaire", derivedFrom, requiresCanonicals);
 
-            ScanForSDCExtensionCanonicals(requiresCanonicals, resource);
+            ScanForSDCExtensionCanonicals(pd, requiresCanonicals, resource);
 
-            ScanForCanonicalsR5(requiresCanonicals, resource, resource.Item);
+            ScanForCanonicalsR5(pd, requiresCanonicals, resource, resource.Item);
         }
 
-        private void ScanForCanonicalsR5(List<CanonicalDetails> requiresCanonicals, Resource resource, List<r5.Hl7.Fhir.Model.Questionnaire.ItemComponent> items)
+        private void ScanForCanonicalsR5(PackageDetails pd, List<CanonicalDetails> requiresCanonicals, Resource resource, List<r5.Hl7.Fhir.Model.Questionnaire.ItemComponent> items)
         {
             if (items == null)
                 return;
             foreach (var item in items)
             {
-                CheckRequiresCanonical(resource, "ValueSet", item.AnswerValueSet, requiresCanonicals, (value) => { item.AnswerValueSet = value; });
-                CheckRequiresCanonical(resource, "StructureDefinition", item.Definition, requiresCanonicals, (value) => { item.Definition = value; });
+                CheckRequiresCanonical(pd, resource, "ValueSet", item.AnswerValueSet, requiresCanonicals, (value) => { item.AnswerValueSet = value; });
+                CheckRequiresCanonical(pd, resource, "StructureDefinition", item.Definition, requiresCanonicals, (value) => { item.Definition = value; });
 
-                ScanForSDCItemExtensionCanonicals(requiresCanonicals, resource, item);
-                ScanForCanonicalsR5(requiresCanonicals, resource, item.Item);
+                ScanForSDCItemExtensionCanonicals(pd, requiresCanonicals, resource, item);
+                ScanForCanonicalsR5(pd, requiresCanonicals, resource, item.Item);
             }
         }
 
-        private void ScanForSDCExtensionCanonicals(List<CanonicalDetails> requiresCanonicals, DomainResource resource)
+        private void ScanForSDCExtensionCanonicals(PackageDetails pd, List<CanonicalDetails> requiresCanonicals, DomainResource resource)
         {
             // SDC extras
             var tsm = resource.GetExtensionValue<Canonical>("http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-targetStructureMap");
-            CheckRequiresCanonical(resource, "StructureMap", tsm, requiresCanonicals, (value) => { tsm = value; });
+            CheckRequiresCanonical(pd, resource, "StructureMap", tsm, requiresCanonicals, (value) => { tsm = value; });
             var qUrl = resource.GetExtensionValue<Canonical>("http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-subQuestionnaire");
-            CheckRequiresCanonical(resource, "Questionnaire", qUrl, requiresCanonicals, (value) => { qUrl = value; });
+            CheckRequiresCanonical(pd, resource, "Questionnaire", qUrl, requiresCanonicals, (value) => { qUrl = value; });
         }
 
-        private void ScanForSDCItemExtensionCanonicals(List<CanonicalDetails> requiresCanonicals, Resource resource, Element item)
+        private void ScanForSDCItemExtensionCanonicals(PackageDetails pd, List<CanonicalDetails> requiresCanonicals, Resource resource, Element item)
         {
             // Maybe think some more about if we can dynamically also scan the extensions from the definitions and "discover" more...
 
             // SDC extras
             var unitValusetUrl = item.GetExtensionValue<Canonical>("http://hl7.org/fhir/StructureDefinition/questionnaire-unitValueSet");
-            CheckRequiresCanonical(resource, "ValueSet", unitValusetUrl, requiresCanonicals, (value) => { unitValusetUrl = value; });
+            CheckRequiresCanonical(pd, resource, "ValueSet", unitValusetUrl, requiresCanonicals, (value) => { unitValusetUrl = value; });
             var referenceProfile = item.GetExtensionValue<Canonical>("http://hl7.org/fhir/StructureDefinition/questionnaire-referenceProfile");
-            CheckRequiresCanonical(resource, "StructureDefinition", unitValusetUrl, requiresCanonicals, (value) => { unitValusetUrl = value; });
+            CheckRequiresCanonical(pd, resource, "StructureDefinition", unitValusetUrl, requiresCanonicals, (value) => { unitValusetUrl = value; });
         }
 		#endregion
 
@@ -806,7 +810,7 @@ namespace UploadFIG
 				// iteratively check if there are more contained resource that haven't been loaded as more are included in the set.
 				var localCanonicals = allRequiredCanonicals.Where(c => pd.Files.Any(f => f.url == c.Canonical)).ToArray();
 				LoadCanonicalResource(pd, localCanonicals, versionAgnosticProcessor, errFiles);
-				allRequiredCanonicals = allRequiredCanonicals.Union(ScanForCanonicals(allRequiredCanonicals, pd.resources.Except(existingResources))).ToList();
+				allRequiredCanonicals = allRequiredCanonicals.Union(ScanForCanonicals(pd, allRequiredCanonicals, pd.resources.Except(existingResources))).ToList();
 				unloadedRequiredLocalResources = pd.Files.Where(f => !f.detectedInvalidContent && allRequiredCanonicals.Any(cd => cd.Canonical == f.url && !pd.resources.Any(r => r.TypeName == f.resourceType && r.Id == f.id))).ToList();
 				safetyCatch++;
 				existingResources = pd.resources.ToList();

--- a/UploadFIG/DependencyChecker.cs
+++ b/UploadFIG/DependencyChecker.cs
@@ -1164,7 +1164,7 @@ namespace UploadFIG
 
 						// Skip resource types we're not intentionally importing
 						// (usually examples)
-						if (!resourceTypeNames.Contains(resource.TypeName))
+						if (resourceTypeNames.Any() && !resourceTypeNames.Contains(resource.TypeName))
 						{
 							if (verbose)
 								Console.WriteLine($"    ----> Ignoring {exampleName} because {resource.TypeName} is not a requested type");

--- a/UploadFIG/DependencyChecker.cs
+++ b/UploadFIG/DependencyChecker.cs
@@ -223,7 +223,7 @@ namespace UploadFIG
 						if (requiresCanonicals.Any(c => c.Canonical == canonical.Value))
 							continue;
 						if (!IsCoreOrExtensionOrToolsCanonical(canonical.Value))
-							CheckRequiresCanonical(pd, resource, "unknown", canonical.Value, requiresCanonicals, (newValue) => canonical.Value = newValue);
+							CheckRequiresCanonical(pd, resource, "unknown", canonical.Value, requiresCanonicals);
 					}
 				}
 			}
@@ -237,7 +237,7 @@ namespace UploadFIG
             {
                 if (child is Extension extension)
                 {
-                    CheckRequiresCanonical(pd, resource, "StructureDefinition", extension.Url, requiresCanonicals, (value) => extension.Url = value);
+                    CheckRequiresCanonical(pd, resource, "StructureDefinition", extension.Url, requiresCanonicals);
                     if (extension.Value != null)
                     {
                         // This will scan for extensions on extension values (not complex extensions)
@@ -428,7 +428,7 @@ namespace UploadFIG
 			"vsacOpModifier",
 		});
 
-        private void CheckRequiresCanonical(PackageDetails pd, Resource resource, string canonicalType, string canonicalUrl, List<CanonicalDetails> requiresCanonicals, Action<string> patchVersionedCanonical = null)
+        private void CheckRequiresCanonical(PackageDetails pd, Resource resource, string canonicalType, string canonicalUrl, List<CanonicalDetails> requiresCanonicals)
         {
 			if (!string.IsNullOrEmpty(canonicalUrl))
             {
@@ -482,13 +482,13 @@ namespace UploadFIG
 
         private void ScanForCanonicalsR4(PackageDetails pd, List<CanonicalDetails> requiresCanonicals, r4.Hl7.Fhir.Model.ConceptMap resource)
         {
-            CheckRequiresCanonical(pd, resource, "ValueSet", resource.Source as Canonical, requiresCanonicals, (value) => (resource.Source as Canonical).Value = value);
-            CheckRequiresCanonical(pd, resource, "ValueSet", resource.Target as Canonical, requiresCanonicals, (value) => (resource.Target as Canonical).Value = value);
+            CheckRequiresCanonical(pd, resource, "ValueSet", resource.Source as Canonical, requiresCanonicals);
+            CheckRequiresCanonical(pd, resource, "ValueSet", resource.Target as Canonical, requiresCanonicals);
 
             foreach (var group in resource.Group)
             {
-                CheckRequiresCanonical(pd, resource, "CodeSystem", group.Source, requiresCanonicals, (value) => { group.Source = value; });
-                CheckRequiresCanonical(pd, resource, "CodeSystem", group.Target, requiresCanonicals, (value) => { group.Target = value; });
+                CheckRequiresCanonical(pd, resource, "CodeSystem", group.Source, requiresCanonicals);
+                CheckRequiresCanonical(pd, resource, "CodeSystem", group.Target, requiresCanonicals);
 
                 foreach (var element in group.Element)
                 {
@@ -496,30 +496,30 @@ namespace UploadFIG
                     {
                         foreach (var dependsOn in target.DependsOn)
                         {
-                            CheckRequiresCanonical(pd, resource, "CodeSystem", dependsOn.System, requiresCanonicals, (value) => { dependsOn.System = value; });
+                            CheckRequiresCanonical(pd, resource, "CodeSystem", dependsOn.System, requiresCanonicals);
                         }
                         foreach (var product in target.Product)
                         {
-                            CheckRequiresCanonical(pd, resource, "CodeSystem", product.System, requiresCanonicals, (value) => { product.System = value; });
+                            CheckRequiresCanonical(pd, resource, "CodeSystem", product.System, requiresCanonicals);
                         }
                     }
                 }
                 if (group.Unmapped?.Url != null)
                 {
-                    CheckRequiresCanonical(pd, resource, "ConceptMap", group.Unmapped.Url, requiresCanonicals, (value) => { group.Unmapped.Url = value; });
+                    CheckRequiresCanonical(pd, resource, "ConceptMap", group.Unmapped.Url, requiresCanonicals);
                 }
             }
         }
 
         private void ScanForCanonicals(PackageDetails pd, List<CanonicalDetails> requiresCanonicals, r4b.Hl7.Fhir.Model.ConceptMap resource)
         {
-            CheckRequiresCanonical(pd, resource, "ValueSet", resource.Source as Canonical, requiresCanonicals, (value) => (resource.Source as Canonical).Value = value);
-            CheckRequiresCanonical(pd, resource, "ValueSet", resource.Target as Canonical, requiresCanonicals, (value) => (resource.Target as Canonical).Value = value);
+            CheckRequiresCanonical(pd, resource, "ValueSet", resource.Source as Canonical, requiresCanonicals);
+            CheckRequiresCanonical(pd, resource, "ValueSet", resource.Target as Canonical, requiresCanonicals);
 
             foreach (var group in resource.Group)
             {
-                CheckRequiresCanonical(pd, resource, "CodeSystem", group.Source, requiresCanonicals, (value) => { group.Source = value; });
-                CheckRequiresCanonical(pd, resource, "CodeSystem", group.Target, requiresCanonicals, (value) => { group.Target = value; });
+                CheckRequiresCanonical(pd, resource, "CodeSystem", group.Source, requiresCanonicals);
+                CheckRequiresCanonical(pd, resource, "CodeSystem", group.Target, requiresCanonicals);
 
                 foreach (var element in group.Element)
                 {
@@ -527,17 +527,17 @@ namespace UploadFIG
                     {
                         foreach (var dependsOn in target.DependsOn)
                         {
-                            CheckRequiresCanonical(pd, resource, "CodeSystem", dependsOn.System, requiresCanonicals, (value) => { dependsOn.System = value; });
+                            CheckRequiresCanonical(pd, resource, "CodeSystem", dependsOn.System, requiresCanonicals);
                         }
                         foreach (var product in target.Product)
                         {
-                            CheckRequiresCanonical(pd, resource, "CodeSystem", product.System, requiresCanonicals, (value) => { product.System = value; });
+                            CheckRequiresCanonical(pd, resource, "CodeSystem", product.System, requiresCanonicals);
                         }
                     }
                 }
                 if (group.Unmapped != null)
                 {
-                    CheckRequiresCanonical(pd, resource, "ConceptMap", group.Unmapped.Url, requiresCanonicals, (value) => { group.Unmapped.Url = value; });
+                    CheckRequiresCanonical(pd, resource, "ConceptMap", group.Unmapped.Url, requiresCanonicals);
                 }
             }
         }
@@ -546,37 +546,37 @@ namespace UploadFIG
         {
             foreach (var prop in resource.Property)
             {
-                CheckRequiresCanonical(pd, resource, "CodeSystem", prop.System, requiresCanonicals, (value) => { prop.System = value; });
+                CheckRequiresCanonical(pd, resource, "CodeSystem", prop.System, requiresCanonicals);
             }
             CheckRequiresCanonical(pd, resource, "ValueSet", resource.SourceScope as Canonical ?? (resource.SourceScope as FhirUri)?.Value, requiresCanonicals);
             CheckRequiresCanonical(pd, resource, "ValueSet", resource.TargetScope as Canonical ?? (resource.TargetScope as FhirUri)?.Value, requiresCanonicals);
 
             foreach (var group in resource.Group)
             {
-                CheckRequiresCanonical(pd, resource, "CodeSystem", group.Source, requiresCanonicals, (value) => { group.Source = value; });
-                CheckRequiresCanonical(pd, resource, "CodeSystem", group.Target, requiresCanonicals, (value) => { group.Target = value; });
+                CheckRequiresCanonical(pd, resource, "CodeSystem", group.Source, requiresCanonicals);
+                CheckRequiresCanonical(pd, resource, "CodeSystem", group.Target, requiresCanonicals);
 
                 foreach (var element in group.Element)
                 {
-                    CheckRequiresCanonical(pd, resource, "ValueSet", element.ValueSet, requiresCanonicals, (value) => { element.ValueSet = value; });
+                    CheckRequiresCanonical(pd, resource, "ValueSet", element.ValueSet, requiresCanonicals);
 
                     foreach (var target in element.Target)
                     {
-                        CheckRequiresCanonical(pd, resource, "ValueSet", target.ValueSet, requiresCanonicals, (value) => { target.ValueSet = value; });
+                        CheckRequiresCanonical(pd, resource, "ValueSet", target.ValueSet, requiresCanonicals);
                         foreach (var dependsOn in target.DependsOn)
                         {
-                            CheckRequiresCanonical(pd, resource, "ValueSet", dependsOn.ValueSet, requiresCanonicals, (value) => { dependsOn.ValueSet = value; });
+                            CheckRequiresCanonical(pd, resource, "ValueSet", dependsOn.ValueSet, requiresCanonicals);
                         }
                         foreach (var product in target.Product)
                         {
-                            CheckRequiresCanonical(pd, resource, "ValueSet", product.ValueSet, requiresCanonicals, (value) => { product.ValueSet = value; });
+                            CheckRequiresCanonical(pd, resource, "ValueSet", product.ValueSet, requiresCanonicals);
                         }
                     }
                 }
                 if (group.Unmapped != null)
                 {
-                    CheckRequiresCanonical(pd, resource, "ValueSet", group.Unmapped.ValueSet, requiresCanonicals, (value) => { group.Unmapped.ValueSet = value; });
-                    CheckRequiresCanonical(pd, resource, "ConceptMap", group.Unmapped.OtherMap, requiresCanonicals, (value) => { group.Unmapped.OtherMap = value; });
+                    CheckRequiresCanonical(pd, resource, "ValueSet", group.Unmapped.ValueSet, requiresCanonicals);
+                    CheckRequiresCanonical(pd, resource, "ConceptMap", group.Unmapped.OtherMap, requiresCanonicals);
                 }
             }
         }
@@ -584,7 +584,7 @@ namespace UploadFIG
 
         private void ScanForCanonicals(PackageDetails pd, List<CanonicalDetails> requiresCanonicals, CodeSystem resource)
         {
-            CheckRequiresCanonical(pd, resource, "CodeSystem", resource.Supplements, requiresCanonicals, (value) => { resource.Supplements = value; });
+            CheckRequiresCanonical(pd, resource, "CodeSystem", resource.Supplements, requiresCanonicals);
             // Removing this check for the "complete valueset" reference as this is quite often not there
             // and if others need it, they would have a reference to it.
             // CheckRequiresCanonical(resource, "ValueSet", resource.ValueSet, requiresCanonicals);
@@ -602,7 +602,7 @@ namespace UploadFIG
             {
                 foreach (var include in resource?.Compose?.Include)
                 {
-                    CheckRequiresCanonical(pd, resource, "CodeSystem", include.System, requiresCanonicals, (value) => { include.System = value; });
+                    CheckRequiresCanonical(pd, resource, "CodeSystem", include.System, requiresCanonicals);
                     foreach (var binding in include.ValueSet)
                     {
                         CheckRequiresCanonical(pd, resource, "ValueSet", binding, requiresCanonicals);
@@ -613,7 +613,7 @@ namespace UploadFIG
             {
                 foreach (var exclude in resource?.Compose?.Exclude)
                 {
-                    CheckRequiresCanonical(pd, resource, "CodeSystem", exclude.System, requiresCanonicals, (value) => { exclude.System = value; });
+                    CheckRequiresCanonical(pd, resource, "CodeSystem", exclude.System, requiresCanonicals);
                     foreach (var binding in exclude.ValueSet)
                     {
                         CheckRequiresCanonical(pd, resource, "ValueSet", binding, requiresCanonicals);
@@ -624,9 +624,9 @@ namespace UploadFIG
 
         private void ScanForCanonicals(PackageDetails pd, List<CanonicalDetails> requiresCanonicals, StructureDefinition resource)
         {
-            CheckRequiresCanonical(pd, resource, "StructureDefinition", resource.BaseDefinition, requiresCanonicals, (value) => { resource.BaseDefinition = value; });
+            CheckRequiresCanonical(pd, resource, "StructureDefinition", resource.BaseDefinition, requiresCanonicals);
             var compliesWithProfile = resource.GetExtensionValue<Canonical>("http://hl7.org/fhir/StructureDefinition/structuredefinition-compliesWithProfile");
-            CheckRequiresCanonical(pd, resource, "StructureDefinition", compliesWithProfile?.Value, requiresCanonicals, (value) => { compliesWithProfile.Value = value; });
+            CheckRequiresCanonical(pd, resource, "StructureDefinition", compliesWithProfile?.Value, requiresCanonicals);
 
             if (resource?.Differential?.Element == null)
             {
@@ -669,7 +669,7 @@ namespace UploadFIG
 					foreach (var binding in additionalBindings)
 					{
 						var valueSet = binding.GetExtensionValue<Canonical>("valueSet");
-						CheckRequiresCanonical(pd, resource, "ValueSet", valueSet, requiresCanonicals, (value) => valueSet.Value = value);
+						CheckRequiresCanonical(pd, resource, "ValueSet", valueSet, requiresCanonicals);
 					}
 				}
 
@@ -711,8 +711,8 @@ namespace UploadFIG
                 return;
             foreach (var item in items)
             {
-                CheckRequiresCanonical(pd, resource, "ValueSet", item.AnswerValueSet, requiresCanonicals, (value) => { item.AnswerValueSet = value; });
-                CheckRequiresCanonical(pd, resource, "StructureDefinition", item.Definition, requiresCanonicals, (value) => { item.Definition = value; });
+                CheckRequiresCanonical(pd, resource, "ValueSet", item.AnswerValueSet, requiresCanonicals);
+                CheckRequiresCanonical(pd, resource, "StructureDefinition", item.Definition, requiresCanonicals);
 
                 ScanForSDCItemExtensionCanonicals(pd, requiresCanonicals, resource, item);
                 ScanForCanonicalsR4(pd, requiresCanonicals, resource, item.Item);
@@ -737,8 +737,8 @@ namespace UploadFIG
                 return;
             foreach (var item in items)
             {
-                CheckRequiresCanonical(pd, resource, "ValueSet", item.AnswerValueSet, requiresCanonicals, (value) => { item.AnswerValueSet = value; });
-                CheckRequiresCanonical(pd, resource, "StructureDefinition", item.Definition, requiresCanonicals, (value) => { item.Definition = value; });
+                CheckRequiresCanonical(pd, resource, "ValueSet", item.AnswerValueSet, requiresCanonicals);
+                CheckRequiresCanonical(pd, resource, "StructureDefinition", item.Definition, requiresCanonicals);
 
                 ScanForSDCItemExtensionCanonicals(pd, requiresCanonicals, resource, item);
                 ScanForCanonicals(pd, requiresCanonicals, resource, item.Item);
@@ -763,8 +763,8 @@ namespace UploadFIG
                 return;
             foreach (var item in items)
             {
-                CheckRequiresCanonical(pd, resource, "ValueSet", item.AnswerValueSet, requiresCanonicals, (value) => { item.AnswerValueSet = value; });
-                CheckRequiresCanonical(pd, resource, "StructureDefinition", item.Definition, requiresCanonicals, (value) => { item.Definition = value; });
+                CheckRequiresCanonical(pd, resource, "ValueSet", item.AnswerValueSet, requiresCanonicals);
+                CheckRequiresCanonical(pd, resource, "StructureDefinition", item.Definition, requiresCanonicals);
 
                 ScanForSDCItemExtensionCanonicals(pd, requiresCanonicals, resource, item);
                 ScanForCanonicalsR5(pd, requiresCanonicals, resource, item.Item);
@@ -775,9 +775,9 @@ namespace UploadFIG
         {
             // SDC extras
             var tsm = resource.GetExtensionValue<Canonical>("http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-targetStructureMap");
-            CheckRequiresCanonical(pd, resource, "StructureMap", tsm, requiresCanonicals, (value) => { tsm = value; });
+            CheckRequiresCanonical(pd, resource, "StructureMap", tsm, requiresCanonicals);
             var qUrl = resource.GetExtensionValue<Canonical>("http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-subQuestionnaire");
-            CheckRequiresCanonical(pd, resource, "Questionnaire", qUrl, requiresCanonicals, (value) => { qUrl = value; });
+            CheckRequiresCanonical(pd, resource, "Questionnaire", qUrl, requiresCanonicals);
         }
 
         private void ScanForSDCItemExtensionCanonicals(PackageDetails pd, List<CanonicalDetails> requiresCanonicals, Resource resource, Element item)
@@ -786,9 +786,9 @@ namespace UploadFIG
 
             // SDC extras
             var unitValusetUrl = item.GetExtensionValue<Canonical>("http://hl7.org/fhir/StructureDefinition/questionnaire-unitValueSet");
-            CheckRequiresCanonical(pd, resource, "ValueSet", unitValusetUrl, requiresCanonicals, (value) => { unitValusetUrl = value; });
+            CheckRequiresCanonical(pd, resource, "ValueSet", unitValusetUrl, requiresCanonicals);
             var referenceProfile = item.GetExtensionValue<Canonical>("http://hl7.org/fhir/StructureDefinition/questionnaire-referenceProfile");
-            CheckRequiresCanonical(pd, resource, "StructureDefinition", unitValusetUrl, requiresCanonicals, (value) => { unitValusetUrl = value; });
+            CheckRequiresCanonical(pd, resource, "StructureDefinition", unitValusetUrl, requiresCanonicals);
         }
 		#endregion
 

--- a/UploadFIG/ExpressionValidator.cs
+++ b/UploadFIG/ExpressionValidator.cs
@@ -265,9 +265,11 @@ namespace UploadFIG
 					ConsoleEx.Write(ConsoleColor.Yellow, ResourcePackageSource.PackageSourceVersion(useResource));
 					Console.WriteLine($" from {String.Join(", ", distinctVersionSources)}");
 				}
-				cd.resource = useResource as Resource;
+                useResource.MarkUsedBy(useResource.resource);
+				cd.resource = useResource.resource as Resource;
 			}
-			return useResource as Resource;
+
+            return useResource?.resource as Resource;
 		}
 
 		public Resource ResolveByUri(string uri)

--- a/UploadFIG/ExpressionValidator.cs
+++ b/UploadFIG/ExpressionValidator.cs
@@ -59,7 +59,7 @@ namespace UploadFIG
 					validationErrors++;
 
 				// Check if there are any types in the differentials that aren't valid for this version of FHIR
-				if (sd.Differential?.Element?.Any() == true)
+				if (sd.Kind != StructureDefinition.StructureDefinitionKind.Logical && sd.Differential?.Element?.Any() == true)
 				{
 					foreach (var element in sd.Differential.Element)
 					{
@@ -69,7 +69,7 @@ namespace UploadFIG
 						}
 					}
 				}
-				if (sd.Snapshot?.Element?.Any() == true)
+				if (sd.Kind != StructureDefinition.StructureDefinitionKind.Logical && sd.Snapshot?.Element?.Any() == true)
 				{
 					foreach (var element in sd.Snapshot.Element)
 					{

--- a/UploadFIG/PackageHelpers/PackageDetails.cs
+++ b/UploadFIG/PackageHelpers/PackageDetails.cs
@@ -12,7 +12,7 @@ namespace UploadFIG.PackageHelpers
 
 		public IEnumerable<Hl7.Fhir.Model.Resource> resources { get
 			{
-				return Files.Select(f => f.resource).Where(r => r != null);
+				return Files.Where(f => f.resource != null && f.UsedBy.Any()).Select(f => f.resource);
 			}
 		}
 

--- a/UploadFIG/PackageHelpers/PackageDetails.cs
+++ b/UploadFIG/PackageHelpers/PackageDetails.cs
@@ -22,7 +22,7 @@ namespace UploadFIG.PackageHelpers
 
 		public Dictionary<string, FileDetail> CanonicalFiles { get; set; } = new Dictionary<string, FileDetail>();
 
-		public IEnumerable<CanonicalDetails> RequiresCanonicals { get; set; } = new List<CanonicalDetails>();	
+		public List<CanonicalDetails> RequiresCanonicals { get; private set; } = new List<CanonicalDetails>();	
 
 		public IEnumerable<CanonicalDetails> UnresolvedCanonicals {  get { return RequiresCanonicals.Where(c => c.resource == null).ToArray(); } }
 

--- a/UploadFIG/PackageHelpers/PackageIndex.cs
+++ b/UploadFIG/PackageHelpers/PackageIndex.cs
@@ -1,4 +1,6 @@
 ﻿using System.Text.Json.Serialization;
+using Hl7.Fhir.ElementModel;
+using Hl7.Fhir.Model;
 
 namespace UploadFIG
 {
@@ -37,5 +39,21 @@ namespace UploadFIG
 
 		[JsonIgnore]
 		public bool hasDuplicateDefinitions { get; set; } = false;
-	}
+
+        /// <summary>
+        /// Still need to work out what this is indexing here, but an empty value means it's not used and can be ignored
+        /// </summary>
+        [JsonIgnore]
+        public List<string> UsedBy { get; set; } = new ();
+
+        public void MarkUsedBy(CanonicalDetails details)
+        {
+            MarkUsedBy(details.requiredBy.First());
+        }
+
+        public void MarkUsedBy(Resource resource)
+        {
+            UsedBy.Add($"{resource.TypeName}/{resource.Id}");
+        }
+    }
 }

--- a/UploadFIG/PackageHelpers/PackageIndex.cs
+++ b/UploadFIG/PackageHelpers/PackageIndex.cs
@@ -40,6 +40,9 @@ namespace UploadFIG
 		[JsonIgnore]
 		public bool hasDuplicateDefinitions { get; set; } = false;
 
+        [JsonIgnore]
+        public bool? ScannedForDependencies;
+
         /// <summary>
         /// Still need to work out what this is indexing here, but an empty value means it's not used and can be ignored
         /// </summary>

--- a/UploadFIG/PackageHelpers/PackageReader.cs
+++ b/UploadFIG/PackageHelpers/PackageReader.cs
@@ -154,6 +154,11 @@ namespace UploadFIG
 								packageStream.Dispose();
 						}
 					}
+                    else
+                    {
+                        // Unable to resolve the package dependency!
+                        ConsoleEx.WriteLine(ConsoleColor.Red, $"{logTabPrefix}    {versionedPackageId} - unable to load package");
+                    }
                 }
             }
 			GC.Collect();

--- a/UploadFIG/PackageHelpers/ResourcePackageSourceAnnotation.cs
+++ b/UploadFIG/PackageHelpers/ResourcePackageSourceAnnotation.cs
@@ -25,5 +25,21 @@ namespace UploadFIG
 			}
 			return null;
 		}
-	}
+        public static string PackageSourceVersion(FileDetail detail)
+        {
+            var att = detail.resource.Annotation<ResourcePackageSource>();
+            if (att != null)
+            {
+                if (detail.resource is IVersionableConformanceResource ivr)
+                {
+                    var result = $"{ivr.Version} ({att.PackageId}|{att.PackageVersion}";
+                    if (ivr.Status == PublicationStatus.Retired)
+                        result += " <retired>";
+                    result += ")";
+                    return result;
+                }
+            }
+            return null;
+        }
+    }
 }

--- a/UploadFIG/Program.cs
+++ b/UploadFIG/Program.cs
@@ -210,6 +210,10 @@ namespace UploadFIG
                 return new Result { Value = -1 };
             }
 
+            if (settings.ResourceTypes.Count == 1 && settings.ResourceTypes[0] == "*")
+            {
+                settings.ResourceTypes.Clear();
+            }
 			Console.WriteLine();
 
 			// Select the version of the processor to use

--- a/UploadFIG/Program.cs
+++ b/UploadFIG/Program.cs
@@ -313,7 +313,7 @@ namespace UploadFIG
 			// however may have a dependency introduced elsewhere in the dependency tree
 			// these ones probably shouldn't be marked with versioned canonicals
 			// This will use the "most recent" version if there are multiple that will resolve.
-			var allUnresolvedCanonicals = depChecker.UnresolvedCanonicals(pd).ToList();
+			var allUnresolvedCanonicals = MergeDistinctCanonicalDetails(depChecker.UnresolvedCanonicals(pd)).ToList();
 			foreach (var canonicalUrl in allUnresolvedCanonicals.ToArray())
 			{
 				// is this canonical in the list of resources....
@@ -761,6 +761,25 @@ namespace UploadFIG
 
             return result;
 		}
+
+        private static List<CanonicalDetails> MergeDistinctCanonicalDetails(IEnumerable<CanonicalDetails> cds)
+        {
+            var result = new List<CanonicalDetails>();
+            var comparer = new CanonicalDetailsComparer();
+            foreach (var item in cds)
+            {
+                var existing = result.FirstOrDefault((t) => comparer.Equals(t,item));
+                if (existing != null)
+                {
+                    existing.requiredBy.AddRange(item.requiredBy.Where(v => !existing.requiredBy.Contains(v)));
+                }
+                else
+                {
+                    result.Add(item);
+                }
+            }
+            return result;
+        }
 
 		private static async Task WriteOutputBundleFile(Settings settings, Bundle alternativeOutputBundle, PackageManifest manifest, Common_Processor versionAgnosticProcessor, List<CanonicalDetails> allUnresolvedCanonicals)
 		{

--- a/UploadFIG/Program.cs
+++ b/UploadFIG/Program.cs
@@ -221,7 +221,16 @@ namespace UploadFIG
 			ExpressionValidator expressionValidator = null;
 			FHIRVersion? fhirVersion = null;
 			var versionInPackage = manifest.GetFhirVersion();
-			if (versionInPackage.StartsWith(FHIRVersion.N4_0.GetLiteral()))
+            if (versionInPackage == null)
+            {
+                // There was no manifest
+                ConsoleEx.WriteLine(ConsoleColor.Red, $"Cannot load/test a FHIR Implementation Guide Package where the manifest does not define a fhir version (package.json)");
+                ConsoleEx.WriteLine(ConsoleColor.Red, $"e.g. \"fhirVersions\" : [\"4.0.1\"]");
+                return new Result { Value = -1 };
+
+                // Note: Could try and "deduce" the fhir version from which fhir core packages are included, however those aren't mandatory either
+            }
+            else if (versionInPackage.StartsWith(FHIRVersion.N4_0.GetLiteral()))
 			{
 				fhirVersion = EnumUtility.ParseLiteral<FHIRVersion>(r4.Hl7.Fhir.Model.ModelInfo.Version);
 				versionAgnosticProcessor = new R4_Processor();

--- a/UploadFIG/Program.cs
+++ b/UploadFIG/Program.cs
@@ -283,15 +283,16 @@ namespace UploadFIG
 				var useResource = CurrentCanonicalFromPackages.Current(matches);
 				if (useResource != null)
 				{
-					var distinctVersionSources = matches.Select(m => ResourcePackageSource.PackageSourceVersion(m)).Distinct();
+					var distinctVersionSources = matches.Select(m => ResourcePackageSource.PackageSourceVersion(m.resource as IVersionableConformanceResource)).Distinct();
 					if (distinctVersionSources.Count() > 1 && settings.Verbose)
 					{
 						Console.Write($"    Resolved {canonicalUrl.Canonical}|{canonicalUrl.Version} with ");
 						ConsoleEx.Write(ConsoleColor.Yellow, ResourcePackageSource.PackageSourceVersion(useResource));
 						Console.WriteLine($" from {String.Join(", ", distinctVersionSources)}");
 					}
-					canonicalUrl.resource = useResource as Resource;
-					allUnresolvedCanonicals.Remove(canonicalUrl);
+					canonicalUrl.resource = useResource.resource as Resource;
+                    useResource.MarkUsedBy(canonicalUrl);
+                    allUnresolvedCanonicals.Remove(canonicalUrl);
 				}
 			}
 

--- a/UploadFIG/Program.cs
+++ b/UploadFIG/Program.cs
@@ -214,7 +214,7 @@ namespace UploadFIG
             {
                 settings.ResourceTypes.Clear();
             }
-			Console.WriteLine();
+            Console.WriteLine();
 
 			// Select the version of the processor to use
 			Common_Processor versionAgnosticProcessor = null;
@@ -280,7 +280,7 @@ namespace UploadFIG
 			packageCache.RegisterPackage(manifest.Name, manifest.Version, sourceStream);
 			var pd = PackageReader.ReadPackageIndexDetails(sourceStream, packageCache, settings.IgnorePackages);
             PackageReader.ReadAdditionalPackageIndexDetails(pd, settings.AdditionalPackages, packageCache, settings.IgnorePackages);
-            var depChecker = new DependencyChecker(settings, fhirVersion.Value, versionAgnosticProcessor.ModelInspector, packageCache);
+            var depChecker = new DependencyChecker(settings, fhirVersion.Value, versionAgnosticProcessor.ModelInspector, packageCache, versionAgnosticProcessor, errFiles);
 
 			// Validate the settings files to skip (ensuring that there are no files that are not in the package)
 			ValidateFileInclusionAndExclusionSettings(settings, pd);
@@ -412,7 +412,7 @@ namespace UploadFIG
 			var registryCanonicals = new List<CanonicalDetails>();
 
 			// Check for missing canonicals on the registry
-			List<Resource> additionalResourcesFromRegistry = await ScanExternalRegistry(settings, versionAgnosticProcessor, depChecker, externalCanonicals, allUnresolvedCanonicals, registryCanonicals);
+			List<Resource> additionalResourcesFromRegistry = await ScanExternalRegistry(pd, settings, versionAgnosticProcessor, depChecker, externalCanonicals, allUnresolvedCanonicals, registryCanonicals);
 			dependencyResourcesToLoad.InsertRange(0, additionalResourcesFromRegistry);
 
 			Console.WriteLine();
@@ -1123,7 +1123,7 @@ namespace UploadFIG
 			}
 		}
 
-		private static async Task<List<Resource>> ScanExternalRegistry(Settings settings, Common_Processor versionAgnosticProcessor, DependencyChecker depChecker, List<CanonicalDetails> externalCanonicals, List<CanonicalDetails> unresolvableCanonicals, List<CanonicalDetails> indirectCanonicals)
+		private static async Task<List<Resource>> ScanExternalRegistry(PackageDetails pd, Settings settings, Common_Processor versionAgnosticProcessor, DependencyChecker depChecker, List<CanonicalDetails> externalCanonicals, List<CanonicalDetails> unresolvableCanonicals, List<CanonicalDetails> indirectCanonicals)
 		{
 			List<Resource> additionalResources = new List<Resource>();
 			if (!string.IsNullOrEmpty(settings.ExternalRegistry))
@@ -1206,7 +1206,7 @@ namespace UploadFIG
 					Canonical = (ec as IVersionableConformanceResource).Url,
 					Version = (ec as IVersionableConformanceResource).Version
 				}).ToList();
-				var dependentCanonicals = depChecker.ScanForCanonicals(initialCanonicals.Union(externalCanonicals), additionalResources);
+				var dependentCanonicals = depChecker.ScanForCanonicals(pd, initialCanonicals.Union(externalCanonicals), additionalResources);
 				foreach (var dc in dependentCanonicals)
 				{
 					try

--- a/UploadFIG/Program.cs
+++ b/UploadFIG/Program.cs
@@ -869,7 +869,7 @@ namespace UploadFIG
 						if (!definedCanonicals.Contains(ivr.Url))
 							definedCanonicals.Add(ivr.Url);
 						definedCanonicals.Add(versionedCanonical);
-						if (futureCanonicals.ContainsKey(ivr.Url))
+						if (ivr.Url != null && futureCanonicals.ContainsKey(ivr.Url))
 							futureCanonicals.Remove(ivr.Url);
 						if (futureCanonicals.ContainsKey(versionedCanonical))
 							futureCanonicals.Remove(versionedCanonical);
@@ -911,7 +911,7 @@ namespace UploadFIG
 								if (!definedCanonicals.Contains(ivr.Url))
 									definedCanonicals.Add(ivr.Url);
 								definedCanonicals.Add(versionedCanonical);
-								if (futureCanonicals.ContainsKey(ivr.Url))
+                                if (ivr.Url != null && futureCanonicals.ContainsKey(ivr.Url))
 									futureCanonicals.Remove(ivr.Url);
 								if (futureCanonicals.ContainsKey(versionedCanonical))
 									futureCanonicals.Remove(versionedCanonical);


### PR DESCRIPTION
* Issue [#21](https://github.com/brianpos/UploadFIG/issues/21) Resource Types `*` to not filter out any types (default is a subset of canonicals)
* Better handling of tree shaking dependent resources that aren't scoped in (as newer versions are already in scope)
* Don't test the types in a logical model as they aren't FHIR types.
* Fixed issue [#24](https://github.com/brianpos/UploadFIG/issues/24) Obscure error when package doesn't define the FHIR version
* Report an error if the package dependency can't be loaded (e.g. requesting `current` version)
